### PR TITLE
feat(calendar): Riverpod 기반 캘린더 기능(모델/컨트롤러/UI) 초기 구현

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Flutter (1.0.0)
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  sqflite_darwin:
+    :path: ".symlinks/plugins/sqflite_darwin/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02502D8684BDA5122553B791 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D55FAFDD32490B89E37ED5F /* Pods_Runner.framework */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		1CFFD22F9657E112321D8603 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AAF0B8C4E6873A793D23EF06 /* Pods_RunnerTests.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
@@ -46,10 +48,14 @@
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		4B9982A425729D4776FADF64 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		5A068DDA7BB8330903513CCD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		6BE4F807384AC36B13392915 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7D55FAFDD32490B89E37ED5F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -57,19 +63,46 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AAF0B8C4E6873A793D23EF06 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB44BB73A6861DEE0DA8F427 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		AF285735E22CA716385D5F67 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		DA3DB9D1828A4FA2D9CF8D1F /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		298D38F36620E7809D209A11 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1CFFD22F9657E112321D8603 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				02502D8684BDA5122553B791 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1EA23120530829B2A92F0E9E /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				DA3DB9D1828A4FA2D9CF8D1F /* Pods-Runner.debug.xcconfig */,
+				4B9982A425729D4776FADF64 /* Pods-Runner.release.xcconfig */,
+				5A068DDA7BB8330903513CCD /* Pods-Runner.profile.xcconfig */,
+				6BE4F807384AC36B13392915 /* Pods-RunnerTests.debug.xcconfig */,
+				AB44BB73A6861DEE0DA8F427 /* Pods-RunnerTests.release.xcconfig */,
+				AF285735E22CA716385D5F67 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C8082294A63A400263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -96,6 +129,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				1EA23120530829B2A92F0E9E /* Pods */,
+				BC519B7FF2BB40FF649C7BDC /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -124,6 +159,15 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		BC519B7FF2BB40FF649C7BDC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7D55FAFDD32490B89E37ED5F /* Pods_Runner.framework */,
+				AAF0B8C4E6873A793D23EF06 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -131,8 +175,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				06A5F834F8E230A13D115604 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				298D38F36620E7809D209A11 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -148,12 +194,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				6F558F2B337715329D1CABCA /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				E0491D00C5A9CCAC898E4866 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -225,6 +273,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		06A5F834F8E230A13D115604 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -241,6 +311,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		6F558F2B337715329D1CABCA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -255,6 +347,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		E0491D00C5A9CCAC898E4866 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -382,6 +491,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6BE4F807384AC36B13392915 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -399,6 +509,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AB44BB73A6861DEE0DA8F427 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -414,6 +525,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AF285735E22CA716385D5F67 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/controllers/calendar_controller.dart
+++ b/lib/controllers/calendar_controller.dart
@@ -1,0 +1,383 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../core/theme/app_theme.dart';
+import '../core/utils/calendar_utils.dart';
+import '../models/calendar/calendar_event.dart';
+
+part 'calendar_controller.freezed.dart';
+
+/// 캘린더 이벤트 인덱스 (날짜별 이벤트 + 슬롯 정보)
+class CalendarEventIndex {
+  CalendarEventIndex({
+    required this.eventsByDay,
+    required this.eventSlots,
+    required this.overflowByDay,
+  });
+
+  /// 날짜별 이벤트 목록 (key: "yyyy-MM-dd")
+  final Map<String, List<CalendarEvent>> eventsByDay;
+
+  /// 이벤트별 슬롯 위치 (key: eventId)
+  final Map<String, int> eventSlots;
+
+  /// 날짜별 오버플로우 카운트 (key: "yyyy-MM-dd")
+  final Map<String, int> overflowByDay;
+
+  static const int maxVisibleEvents = 3;
+
+  /// 빈 인덱스
+  factory CalendarEventIndex.empty() => CalendarEventIndex(
+        eventsByDay: {},
+        eventSlots: {},
+        overflowByDay: {},
+      );
+
+  /// 월 단위로 이벤트 인덱스 생성
+  factory CalendarEventIndex.build(
+    DateTime month,
+    List<CalendarEvent> events,
+  ) {
+    final days = CalendarUtils.getDaysInMonth(month);
+    final eventsByDay = <String, List<CalendarEvent>>{};
+    final eventSlots = <String, int>{};
+    final overflowByDay = <String, int>{};
+
+    // 주(week) 단위로 분할
+    final weeks = <List<DateTime>>[];
+    for (var i = 0; i < days.length; i += 7) {
+      weeks.add(days.sublist(i, i + 7));
+    }
+
+    // 각 주별로 슬롯 할당
+    for (final week in weeks) {
+      final weekStart = week.first;
+      final weekEvents = CalendarUtils.getEventsForWeek(weekStart, events)
+        ..sort((a, b) {
+          final startCompare = a.startDate.compareTo(b.startDate);
+          if (startCompare != 0) return startCompare;
+          return b.durationInDays.compareTo(a.durationInDays);
+        });
+
+      // 슬롯 할당
+      final usedSlots = List.generate(7, (_) => <int>{});
+      for (final event in weekEvents) {
+        final dayIndices = <int>[];
+        for (var i = 0; i < 7; i++) {
+          if (event.occursOnDay(week[i])) {
+            dayIndices.add(i);
+          }
+        }
+        if (dayIndices.isEmpty) continue;
+
+        var slot = 0;
+        while (true) {
+          var canUse = true;
+          for (final dayIndex in dayIndices) {
+            if (usedSlots[dayIndex].contains(slot)) {
+              canUse = false;
+              break;
+            }
+          }
+          if (canUse) break;
+          slot++;
+        }
+
+        eventSlots[event.id] = slot;
+        for (final dayIndex in dayIndices) {
+          usedSlots[dayIndex].add(slot);
+        }
+      }
+    }
+
+    // 날짜별 이벤트 & 오버플로우 계산
+    for (final day in days) {
+      final key = _dateKey(day);
+      final dayEvents = events.where((e) => e.occursOnDay(day)).toList()
+        ..sort((a, b) {
+          final slotA = eventSlots[a.id] ?? 999;
+          final slotB = eventSlots[b.id] ?? 999;
+          return slotA.compareTo(slotB);
+        });
+
+      eventsByDay[key] = dayEvents;
+      if (dayEvents.length > maxVisibleEvents) {
+        overflowByDay[key] = dayEvents.length - maxVisibleEvents;
+      }
+    }
+
+    return CalendarEventIndex(
+      eventsByDay: eventsByDay,
+      eventSlots: eventSlots,
+      overflowByDay: overflowByDay,
+    );
+  }
+
+  static String _dateKey(DateTime date) =>
+      '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+
+  /// 특정 날짜의 이벤트 조회 O(1)
+  List<CalendarEvent> getEventsForDay(DateTime day) {
+    return eventsByDay[_dateKey(day)] ?? [];
+  }
+
+  /// 특정 날짜의 오버플로우 카운트 조회 O(1)
+  int getOverflowCount(DateTime day) {
+    return overflowByDay[_dateKey(day)] ?? 0;
+  }
+
+  /// 이벤트의 슬롯 조회 O(1)
+  int getSlot(String eventId) {
+    return eventSlots[eventId] ?? 0;
+  }
+}
+
+/// 캘린더 상태
+@freezed
+class CalendarState with _$CalendarState {
+  const factory CalendarState({
+    required DateTime focusedMonth,
+    DateTime? selectedDate,
+    @Default([]) List<CalendarEvent> events,
+    @Default(false) bool isLoading,
+  }) = _CalendarState;
+}
+
+/// 캘린더 컨트롤러 (Notifier)
+class CalendarController extends Notifier<CalendarState> {
+  @override
+  CalendarState build() {
+    final now = DateTime.now();
+    return CalendarState(
+      focusedMonth: DateTime(now.year, now.month, 1),
+      selectedDate: now,
+      events: _generateSampleEvents(),
+    );
+  }
+
+  /// 이전 달로 이동
+  void goToPreviousMonth() {
+    state = state.copyWith(
+      focusedMonth: DateTime(
+        state.focusedMonth.year,
+        state.focusedMonth.month - 1,
+        1,
+      ),
+    );
+  }
+
+  /// 다음 달로 이동
+  void goToNextMonth() {
+    state = state.copyWith(
+      focusedMonth: DateTime(
+        state.focusedMonth.year,
+        state.focusedMonth.month + 1,
+        1,
+      ),
+    );
+  }
+
+  /// 특정 월로 이동
+  void goToMonth(DateTime month) {
+    state = state.copyWith(
+      focusedMonth: DateTime(month.year, month.month, 1),
+    );
+  }
+
+  /// 날짜 선택
+  void selectDate(DateTime date) {
+    state = state.copyWith(selectedDate: date);
+  }
+
+  /// 일정 추가
+  void addEvent(CalendarEvent event) {
+    state = state.copyWith(events: [...state.events, event]);
+  }
+
+  /// 일정 삭제
+  void removeEvent(String eventId) {
+    state = state.copyWith(
+      events: state.events.where((e) => e.id != eventId).toList(),
+    );
+  }
+
+  /// 일정 업데이트
+  void updateEvent(CalendarEvent event) {
+    state = state.copyWith(
+      events: state.events.map((e) => e.id == event.id ? event : e).toList(),
+    );
+  }
+
+  /// 샘플 일정 생성 (데모용)
+  List<CalendarEvent> _generateSampleEvents() {
+    final now = DateTime.now();
+    final year = now.year;
+    final month = now.month;
+
+    // 날짜 문자열 생성 헬퍼
+    String formatDate(int y, int m, int d) =>
+        '$y-${m.toString().padLeft(2, '0')}-${d.toString().padLeft(2, '0')}';
+
+    return [
+      // 시간 설정된 일정 (단일 날짜)
+      CalendarEvent(
+        id: '1',
+        usersId: 1,
+        title: '팀 미팅',
+        startAt: formatDate(year, month, 22),
+        endAt: formatDate(year, month, 22),
+        startTime: '14:00',
+        endTime: '16:00',
+        timeSetting: true,
+        createdAt: DateTime(year, month, 22, 14, 30),
+        color: AppTheme.eventColors[0],
+      ),
+      // 시간 미설정 일정 (여러 날)
+      CalendarEvent(
+        id: '2',
+        usersId: 1,
+        title: '1월 휴가',
+        startAt: formatDate(year, month, 10),
+        endAt: formatDate(year, month, 12),
+        timeSetting: false,
+        createdAt: DateTime(year, month, 1, 9, 0),
+        color: AppTheme.eventColors[1],
+      ),
+      // 체력관리
+      CalendarEvent(
+        id: '3',
+        usersId: 1,
+        title: '체력관...',
+        startAt: formatDate(year, month, 1),
+        endAt: formatDate(year, month, 1),
+        timeSetting: false,
+        createdAt: DateTime(year, month, 1),
+        color: AppTheme.eventColors[1],
+      ),
+      // 시각디자인 (여러 날)
+      CalendarEvent(
+        id: '4',
+        usersId: 1,
+        title: '시각디자인...',
+        startAt: formatDate(year, month, 9),
+        endAt: formatDate(year, month, 13),
+        timeSetting: false,
+        createdAt: DateTime(year, month, 8),
+        color: AppTheme.eventColors[1],
+      ),
+      // 임상실습
+      CalendarEvent(
+        id: '5',
+        usersId: 1,
+        title: '임상실...',
+        startAt: formatDate(year, month, 9),
+        endAt: formatDate(year, month, 9),
+        startTime: '09:00',
+        endTime: '12:00',
+        timeSetting: true,
+        createdAt: DateTime(year, month, 8),
+        color: AppTheme.eventColors[2],
+      ),
+      // 임상실습 2
+      CalendarEvent(
+        id: '6',
+        usersId: 1,
+        title: '임상실...',
+        startAt: formatDate(year, month, 10),
+        endAt: formatDate(year, month, 10),
+        startTime: '09:00',
+        endTime: '12:00',
+        timeSetting: true,
+        createdAt: DateTime(year, month, 8),
+        color: AppTheme.eventColors[2],
+      ),
+      // UX 방법론
+      CalendarEvent(
+        id: '7',
+        usersId: 1,
+        title: 'ux 방...',
+        startAt: formatDate(year, month, 11),
+        endAt: formatDate(year, month, 11),
+        timeSetting: false,
+        createdAt: DateTime(year, month, 10),
+        color: AppTheme.eventColors[2],
+      ),
+      // 물리치료학 (여러 날)
+      CalendarEvent(
+        id: '8',
+        usersId: 1,
+        title: '물리치료학',
+        startAt: formatDate(year, month, 11),
+        endAt: formatDate(year, month, 13),
+        timeSetting: false,
+        createdAt: DateTime(year, month, 10),
+        color: AppTheme.eventColors[0],
+      ),
+      // 미용실
+      CalendarEvent(
+        id: '9',
+        usersId: 1,
+        title: '미용실',
+        startAt: formatDate(year, month, 10),
+        endAt: formatDate(year, month, 10),
+        startTime: '15:00',
+        endTime: '17:00',
+        timeSetting: true,
+        createdAt: DateTime(year, month, 9),
+        color: AppTheme.eventColors[2],
+      ),
+      // 물리치료학 2 (여러 날)
+      CalendarEvent(
+        id: '10',
+        usersId: 1,
+        title: '물리치료학',
+        startAt: formatDate(year, month, 14),
+        endAt: formatDate(year, month, 17),
+        timeSetting: false,
+        createdAt: DateTime(year, month, 13),
+        color: AppTheme.eventColors[0],
+      ),
+      // 크리스마스 파티
+      CalendarEvent(
+        id: '11',
+        usersId: 1,
+        title: '크리스...',
+        startAt: formatDate(year, month, 25),
+        endAt: formatDate(year, month, 25),
+        startTime: '18:00',
+        endTime: '22:00',
+        timeSetting: true,
+        createdAt: DateTime(year, month, 20),
+        color: AppTheme.eventColors[2],
+      ),
+    ];
+  }
+}
+
+/// 캘린더 Provider
+final calendarProvider =
+    NotifierProvider<CalendarController, CalendarState>(CalendarController.new);
+
+/// 선택된 날짜 Provider (셀 단위 리빌드 최적화용)
+final selectedDateProvider = Provider<DateTime?>((ref) {
+  return ref.watch(calendarProvider.select((s) => s.selectedDate));
+});
+
+/// 이벤트 목록 Provider (이벤트 변경 시에만 리빌드)
+final eventsProvider = Provider<List<CalendarEvent>>((ref) {
+  return ref.watch(calendarProvider.select((s) => s.events));
+});
+
+/// 월별 이벤트 인덱스 Provider (Family - 월별로 캐시됨)
+final eventIndexFamilyProvider =
+    Provider.family<CalendarEventIndex, String>((ref, monthKey) {
+  final events = ref.watch(eventsProvider);
+  final parts = monthKey.split('-');
+  final month = DateTime(int.parse(parts[0]), int.parse(parts[1]), 1);
+  return CalendarEventIndex.build(month, events);
+});
+
+/// 월 키 생성 헬퍼
+String getMonthKey(DateTime month) =>
+    '${month.year}-${month.month.toString().padLeft(2, '0')}';

--- a/lib/controllers/calendar_controller.freezed.dart
+++ b/lib/controllers/calendar_controller.freezed.dart
@@ -1,0 +1,237 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'calendar_controller.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+/// @nodoc
+mixin _$CalendarState {
+  DateTime get focusedMonth => throw _privateConstructorUsedError;
+  DateTime? get selectedDate => throw _privateConstructorUsedError;
+  List<CalendarEvent> get events => throw _privateConstructorUsedError;
+  bool get isLoading => throw _privateConstructorUsedError;
+
+  /// Create a copy of CalendarState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CalendarStateCopyWith<CalendarState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CalendarStateCopyWith<$Res> {
+  factory $CalendarStateCopyWith(
+    CalendarState value,
+    $Res Function(CalendarState) then,
+  ) = _$CalendarStateCopyWithImpl<$Res, CalendarState>;
+  @useResult
+  $Res call({
+    DateTime focusedMonth,
+    DateTime? selectedDate,
+    List<CalendarEvent> events,
+    bool isLoading,
+  });
+}
+
+/// @nodoc
+class _$CalendarStateCopyWithImpl<$Res, $Val extends CalendarState>
+    implements $CalendarStateCopyWith<$Res> {
+  _$CalendarStateCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CalendarState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? focusedMonth = null,
+    Object? selectedDate = freezed,
+    Object? events = null,
+    Object? isLoading = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            focusedMonth: null == focusedMonth
+                ? _value.focusedMonth
+                : focusedMonth // ignore: cast_nullable_to_non_nullable
+                      as DateTime,
+            selectedDate: freezed == selectedDate
+                ? _value.selectedDate
+                : selectedDate // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            events: null == events
+                ? _value.events
+                : events // ignore: cast_nullable_to_non_nullable
+                      as List<CalendarEvent>,
+            isLoading: null == isLoading
+                ? _value.isLoading
+                : isLoading // ignore: cast_nullable_to_non_nullable
+                      as bool,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$CalendarStateImplCopyWith<$Res>
+    implements $CalendarStateCopyWith<$Res> {
+  factory _$$CalendarStateImplCopyWith(
+    _$CalendarStateImpl value,
+    $Res Function(_$CalendarStateImpl) then,
+  ) = __$$CalendarStateImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    DateTime focusedMonth,
+    DateTime? selectedDate,
+    List<CalendarEvent> events,
+    bool isLoading,
+  });
+}
+
+/// @nodoc
+class __$$CalendarStateImplCopyWithImpl<$Res>
+    extends _$CalendarStateCopyWithImpl<$Res, _$CalendarStateImpl>
+    implements _$$CalendarStateImplCopyWith<$Res> {
+  __$$CalendarStateImplCopyWithImpl(
+    _$CalendarStateImpl _value,
+    $Res Function(_$CalendarStateImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of CalendarState
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? focusedMonth = null,
+    Object? selectedDate = freezed,
+    Object? events = null,
+    Object? isLoading = null,
+  }) {
+    return _then(
+      _$CalendarStateImpl(
+        focusedMonth: null == focusedMonth
+            ? _value.focusedMonth
+            : focusedMonth // ignore: cast_nullable_to_non_nullable
+                  as DateTime,
+        selectedDate: freezed == selectedDate
+            ? _value.selectedDate
+            : selectedDate // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        events: null == events
+            ? _value._events
+            : events // ignore: cast_nullable_to_non_nullable
+                  as List<CalendarEvent>,
+        isLoading: null == isLoading
+            ? _value.isLoading
+            : isLoading // ignore: cast_nullable_to_non_nullable
+                  as bool,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+
+class _$CalendarStateImpl implements _CalendarState {
+  const _$CalendarStateImpl({
+    required this.focusedMonth,
+    this.selectedDate,
+    final List<CalendarEvent> events = const [],
+    this.isLoading = false,
+  }) : _events = events;
+
+  @override
+  final DateTime focusedMonth;
+  @override
+  final DateTime? selectedDate;
+  final List<CalendarEvent> _events;
+  @override
+  @JsonKey()
+  List<CalendarEvent> get events {
+    if (_events is EqualUnmodifiableListView) return _events;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_events);
+  }
+
+  @override
+  @JsonKey()
+  final bool isLoading;
+
+  @override
+  String toString() {
+    return 'CalendarState(focusedMonth: $focusedMonth, selectedDate: $selectedDate, events: $events, isLoading: $isLoading)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CalendarStateImpl &&
+            (identical(other.focusedMonth, focusedMonth) ||
+                other.focusedMonth == focusedMonth) &&
+            (identical(other.selectedDate, selectedDate) ||
+                other.selectedDate == selectedDate) &&
+            const DeepCollectionEquality().equals(other._events, _events) &&
+            (identical(other.isLoading, isLoading) ||
+                other.isLoading == isLoading));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    focusedMonth,
+    selectedDate,
+    const DeepCollectionEquality().hash(_events),
+    isLoading,
+  );
+
+  /// Create a copy of CalendarState
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CalendarStateImplCopyWith<_$CalendarStateImpl> get copyWith =>
+      __$$CalendarStateImplCopyWithImpl<_$CalendarStateImpl>(this, _$identity);
+}
+
+abstract class _CalendarState implements CalendarState {
+  const factory _CalendarState({
+    required final DateTime focusedMonth,
+    final DateTime? selectedDate,
+    final List<CalendarEvent> events,
+    final bool isLoading,
+  }) = _$CalendarStateImpl;
+
+  @override
+  DateTime get focusedMonth;
+  @override
+  DateTime? get selectedDate;
+  @override
+  List<CalendarEvent> get events;
+  @override
+  bool get isLoading;
+
+  /// Create a copy of CalendarState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CalendarStateImplCopyWith<_$CalendarStateImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -4,6 +4,24 @@ import 'package:flutter/material.dart';
 class AppTheme {
   AppTheme._();
 
+  // 캘린더 색상
+  static const Color sundayColor = Color(0xFFE53935);
+  static const Color saturdayColor = Color(0xFF1E88E5);
+  static const Color todayColor = Color(0xFF4285F4);
+  static const Color selectedDayColor = Color(0xFF4285F4);
+
+  // 일정 기본 색상
+  static const List<Color> eventColors = [
+    Color(0xFF4285F4), // 파랑
+    Color(0xFFFBBC04), // 노랑
+    Color(0xFFB9EF9B), // 초록
+    Color(0xFFEA4335), // 빨강
+    Color(0xFF9C27B0), // 보라
+    Color(0xFFFF9800), // 주황
+    Color(0xFF00BCD4), // 청록
+    Color(0xFF795548), // 갈색
+  ];
+
   static ThemeData get lightTheme {
     return ThemeData(
       useMaterial3: true,

--- a/lib/core/utils/calendar_utils.dart
+++ b/lib/core/utils/calendar_utils.dart
@@ -1,0 +1,119 @@
+import '../../models/calendar/calendar_event.dart';
+
+/// 캘린더 유틸리티 함수 모음
+class CalendarUtils {
+  CalendarUtils._();
+
+  /// 해당 월의 모든 날짜 리스트 반환 (이전/다음 달 날짜 포함)
+  /// 캘린더 그리드에 표시할 주 단위 날짜를 반환
+  static List<DateTime> getDaysInMonth(DateTime month) {
+    final firstDayOfMonth = DateTime(month.year, month.month, 1);
+    final lastDayOfMonth = DateTime(month.year, month.month + 1, 0);
+
+    // 첫 번째 날의 요일 (일요일 = 0)
+    final firstWeekday = firstDayOfMonth.weekday % 7;
+
+    // 캘린더 시작일 (이전 달 포함)
+    final startDate = firstDayOfMonth.subtract(Duration(days: firstWeekday));
+
+    // 필요한 주 수 계산 (최소 5주, 최대 6주)
+    final daysInMonth = lastDayOfMonth.day;
+    final totalCells = firstWeekday + daysInMonth;
+    final weeks = (totalCells / 7).ceil().clamp(5, 6);
+    final totalDays = weeks * 7;
+
+    return List.generate(
+      totalDays,
+      (index) => startDate.add(Duration(days: index)),
+    );
+  }
+
+  /// 해당 월의 주(week) 수 계산
+  static int getWeeksInMonth(DateTime month) {
+    final days = getDaysInMonth(month);
+    return (days.length / 7).ceil();
+  }
+
+  /// 특정 날짜가 해당 월에 속하는지 확인
+  static bool isSameMonth(DateTime date, DateTime month) {
+    return date.year == month.year && date.month == month.month;
+  }
+
+  /// 두 날짜가 같은 날인지 확인
+  static bool isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  /// 오늘 날짜인지 확인
+  static bool isToday(DateTime date) {
+    final now = DateTime.now();
+    return isSameDay(date, now);
+  }
+
+  /// 일요일인지 확인
+  static bool isSunday(DateTime date) {
+    return date.weekday == DateTime.sunday;
+  }
+
+  /// 토요일인지 확인
+  static bool isSaturday(DateTime date) {
+    return date.weekday == DateTime.saturday;
+  }
+
+  /// 특정 날짜에 해당하는 일정 목록 반환
+  static List<CalendarEvent> getEventsForDay(
+    DateTime day,
+    List<CalendarEvent> events,
+  ) {
+    return events.where((event) => event.occursOnDay(day)).toList();
+  }
+
+  /// 특정 주에 해당하는 일정 목록 반환
+  static List<CalendarEvent> getEventsForWeek(
+    DateTime weekStart,
+    List<CalendarEvent> events,
+  ) {
+    final weekEnd = weekStart.add(const Duration(days: 6));
+    return events.where((event) {
+      final eventStart = DateTime(
+        event.startDate.year,
+        event.startDate.month,
+        event.startDate.day,
+      );
+      final eventEnd = DateTime(
+        event.endDate.year,
+        event.endDate.month,
+        event.endDate.day,
+      );
+
+      return eventStart.isBefore(weekEnd.add(const Duration(days: 1))) &&
+          eventEnd.isAfter(weekStart.subtract(const Duration(days: 1)));
+    }).toList();
+  }
+
+  /// 이전 달 계산
+  static DateTime getPreviousMonth(DateTime month) {
+    return DateTime(month.year, month.month - 1, 1);
+  }
+
+  /// 다음 달 계산
+  static DateTime getNextMonth(DateTime month) {
+    return DateTime(month.year, month.month + 1, 1);
+  }
+
+  /// 월 포맷 (예: 2025.12)
+  static String formatMonth(DateTime month) {
+    return '${month.year}.${month.month.toString().padLeft(2, '0')}';
+  }
+
+  /// 요일 헤더 (일~토)
+  static const List<String> weekdayHeaders = [
+    '일',
+    '월',
+    '화',
+    '수',
+    '목',
+    '금',
+    '토',
+  ];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,28 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'core/theme/app_theme.dart';
+import 'views/screens/calendar_screen.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    const ProviderScope(
+      child: MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
+      title: 'POJ Todo',
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
+      home: const CalendarScreen(),
     );
   }
 }

--- a/lib/models/calendar/calendar_event.dart
+++ b/lib/models/calendar/calendar_event.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'calendar_event.freezed.dart';
+part 'calendar_event.g.dart';
+
+/// 캘린더 일정 모델
+@freezed
+class CalendarEvent with _$CalendarEvent {
+  const CalendarEvent._();
+
+  const factory CalendarEvent({
+    /// 클라이언트 식별용 ID (백엔드 ID 또는 자동 생성)
+    required String id,
+
+    /// 사용자 ID
+    required int usersId,
+
+    /// 일정 제목
+    required String title,
+
+    /// 시작 날짜 (YYYY-MM-DD 형식)
+    @JsonKey(name: 'startAt') required String startAt,
+
+    /// 종료 날짜 (YYYY-MM-DD 형식)
+    @JsonKey(name: 'endAt') required String endAt,
+
+    /// 시작 시간 (HH:mm 형식, nullable)
+    String? startTime,
+
+    /// 종료 시간 (HH:mm 형식, nullable)
+    String? endTime,
+
+    /// 시간 설정 여부
+    @Default(false) bool timeSetting,
+
+    /// 생성 일시
+    @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+    DateTime? createdAt,
+
+    /// 표시 색상 (클라이언트 전용, JSON 제외)
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    @Default(Color(0xFF4285F4))
+    Color color,
+  }) = _CalendarEvent;
+
+  factory CalendarEvent.fromJson(Map<String, dynamic> json) =>
+      _$CalendarEventFromJson(json);
+
+  /// 시작 날짜를 DateTime으로 변환
+  DateTime get startDate => DateTime.parse(startAt);
+
+  /// 종료 날짜를 DateTime으로 변환
+  DateTime get endDate => DateTime.parse(endAt);
+
+  /// 일정이 특정 날짜에 해당하는지 확인
+  bool occursOnDay(DateTime day) {
+    final dayStart = DateTime(day.year, day.month, day.day);
+    final dayEnd = dayStart.add(const Duration(days: 1));
+    final eventStart = DateTime(
+      startDate.year,
+      startDate.month,
+      startDate.day,
+    );
+    final eventEnd = DateTime(
+      endDate.year,
+      endDate.month,
+      endDate.day,
+    ).add(const Duration(days: 1));
+
+    return eventStart.isBefore(dayEnd) && eventEnd.isAfter(dayStart);
+  }
+
+  /// 여러 날에 걸친 일정인지 확인
+  bool get isMultiDay {
+    final start = DateTime(startDate.year, startDate.month, startDate.day);
+    final end = DateTime(endDate.year, endDate.month, endDate.day);
+    return start != end;
+  }
+
+  /// 일정 기간 (일 수)
+  int get durationInDays {
+    final start = DateTime(startDate.year, startDate.month, startDate.day);
+    final end = DateTime(endDate.year, endDate.month, endDate.day);
+    return end.difference(start).inDays + 1;
+  }
+
+  /// 시간 포함 시작 DateTime
+  DateTime? get startDateTime {
+    if (!timeSetting || startTime == null) return null;
+    final parts = startTime!.split(':');
+    return DateTime(
+      startDate.year,
+      startDate.month,
+      startDate.day,
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+    );
+  }
+
+  /// 시간 포함 종료 DateTime
+  DateTime? get endDateTime {
+    if (!timeSetting || endTime == null) return null;
+    final parts = endTime!.split(':');
+    return DateTime(
+      endDate.year,
+      endDate.month,
+      endDate.day,
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+    );
+  }
+}
+
+/// JSON에서 DateTime으로 변환
+DateTime? _dateTimeFromJson(String? value) =>
+    value != null ? DateTime.parse(value) : null;
+
+/// DateTime을 JSON으로 변환
+String? _dateTimeToJson(DateTime? dateTime) => dateTime?.toIso8601String();

--- a/lib/models/calendar/calendar_event.freezed.dart
+++ b/lib/models/calendar/calendar_event.freezed.dart
@@ -1,0 +1,450 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'calendar_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+CalendarEvent _$CalendarEventFromJson(Map<String, dynamic> json) {
+  return _CalendarEvent.fromJson(json);
+}
+
+/// @nodoc
+mixin _$CalendarEvent {
+  /// 클라이언트 식별용 ID (백엔드 ID 또는 자동 생성)
+  String get id => throw _privateConstructorUsedError;
+
+  /// 사용자 ID
+  int get usersId => throw _privateConstructorUsedError;
+
+  /// 일정 제목
+  String get title => throw _privateConstructorUsedError;
+
+  /// 시작 날짜 (YYYY-MM-DD 형식)
+  @JsonKey(name: 'startAt')
+  String get startAt => throw _privateConstructorUsedError;
+
+  /// 종료 날짜 (YYYY-MM-DD 형식)
+  @JsonKey(name: 'endAt')
+  String get endAt => throw _privateConstructorUsedError;
+
+  /// 시작 시간 (HH:mm 형식, nullable)
+  String? get startTime => throw _privateConstructorUsedError;
+
+  /// 종료 시간 (HH:mm 형식, nullable)
+  String? get endTime => throw _privateConstructorUsedError;
+
+  /// 시간 설정 여부
+  bool get timeSetting => throw _privateConstructorUsedError;
+
+  /// 생성 일시
+  @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  DateTime? get createdAt => throw _privateConstructorUsedError;
+
+  /// 표시 색상 (클라이언트 전용, JSON 제외)
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  Color get color => throw _privateConstructorUsedError;
+
+  /// Serializes this CalendarEvent to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of CalendarEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $CalendarEventCopyWith<CalendarEvent> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $CalendarEventCopyWith<$Res> {
+  factory $CalendarEventCopyWith(
+    CalendarEvent value,
+    $Res Function(CalendarEvent) then,
+  ) = _$CalendarEventCopyWithImpl<$Res, CalendarEvent>;
+  @useResult
+  $Res call({
+    String id,
+    int usersId,
+    String title,
+    @JsonKey(name: 'startAt') String startAt,
+    @JsonKey(name: 'endAt') String endAt,
+    String? startTime,
+    String? endTime,
+    bool timeSetting,
+    @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+    DateTime? createdAt,
+    @JsonKey(includeFromJson: false, includeToJson: false) Color color,
+  });
+}
+
+/// @nodoc
+class _$CalendarEventCopyWithImpl<$Res, $Val extends CalendarEvent>
+    implements $CalendarEventCopyWith<$Res> {
+  _$CalendarEventCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of CalendarEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? usersId = null,
+    Object? title = null,
+    Object? startAt = null,
+    Object? endAt = null,
+    Object? startTime = freezed,
+    Object? endTime = freezed,
+    Object? timeSetting = null,
+    Object? createdAt = freezed,
+    Object? color = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            id: null == id
+                ? _value.id
+                : id // ignore: cast_nullable_to_non_nullable
+                      as String,
+            usersId: null == usersId
+                ? _value.usersId
+                : usersId // ignore: cast_nullable_to_non_nullable
+                      as int,
+            title: null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                      as String,
+            startAt: null == startAt
+                ? _value.startAt
+                : startAt // ignore: cast_nullable_to_non_nullable
+                      as String,
+            endAt: null == endAt
+                ? _value.endAt
+                : endAt // ignore: cast_nullable_to_non_nullable
+                      as String,
+            startTime: freezed == startTime
+                ? _value.startTime
+                : startTime // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            endTime: freezed == endTime
+                ? _value.endTime
+                : endTime // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            timeSetting: null == timeSetting
+                ? _value.timeSetting
+                : timeSetting // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            createdAt: freezed == createdAt
+                ? _value.createdAt
+                : createdAt // ignore: cast_nullable_to_non_nullable
+                      as DateTime?,
+            color: null == color
+                ? _value.color
+                : color // ignore: cast_nullable_to_non_nullable
+                      as Color,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$CalendarEventImplCopyWith<$Res>
+    implements $CalendarEventCopyWith<$Res> {
+  factory _$$CalendarEventImplCopyWith(
+    _$CalendarEventImpl value,
+    $Res Function(_$CalendarEventImpl) then,
+  ) = __$$CalendarEventImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String id,
+    int usersId,
+    String title,
+    @JsonKey(name: 'startAt') String startAt,
+    @JsonKey(name: 'endAt') String endAt,
+    String? startTime,
+    String? endTime,
+    bool timeSetting,
+    @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+    DateTime? createdAt,
+    @JsonKey(includeFromJson: false, includeToJson: false) Color color,
+  });
+}
+
+/// @nodoc
+class __$$CalendarEventImplCopyWithImpl<$Res>
+    extends _$CalendarEventCopyWithImpl<$Res, _$CalendarEventImpl>
+    implements _$$CalendarEventImplCopyWith<$Res> {
+  __$$CalendarEventImplCopyWithImpl(
+    _$CalendarEventImpl _value,
+    $Res Function(_$CalendarEventImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of CalendarEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? usersId = null,
+    Object? title = null,
+    Object? startAt = null,
+    Object? endAt = null,
+    Object? startTime = freezed,
+    Object? endTime = freezed,
+    Object? timeSetting = null,
+    Object? createdAt = freezed,
+    Object? color = null,
+  }) {
+    return _then(
+      _$CalendarEventImpl(
+        id: null == id
+            ? _value.id
+            : id // ignore: cast_nullable_to_non_nullable
+                  as String,
+        usersId: null == usersId
+            ? _value.usersId
+            : usersId // ignore: cast_nullable_to_non_nullable
+                  as int,
+        title: null == title
+            ? _value.title
+            : title // ignore: cast_nullable_to_non_nullable
+                  as String,
+        startAt: null == startAt
+            ? _value.startAt
+            : startAt // ignore: cast_nullable_to_non_nullable
+                  as String,
+        endAt: null == endAt
+            ? _value.endAt
+            : endAt // ignore: cast_nullable_to_non_nullable
+                  as String,
+        startTime: freezed == startTime
+            ? _value.startTime
+            : startTime // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        endTime: freezed == endTime
+            ? _value.endTime
+            : endTime // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        timeSetting: null == timeSetting
+            ? _value.timeSetting
+            : timeSetting // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        createdAt: freezed == createdAt
+            ? _value.createdAt
+            : createdAt // ignore: cast_nullable_to_non_nullable
+                  as DateTime?,
+        color: null == color
+            ? _value.color
+            : color // ignore: cast_nullable_to_non_nullable
+                  as Color,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$CalendarEventImpl extends _CalendarEvent {
+  const _$CalendarEventImpl({
+    required this.id,
+    required this.usersId,
+    required this.title,
+    @JsonKey(name: 'startAt') required this.startAt,
+    @JsonKey(name: 'endAt') required this.endAt,
+    this.startTime,
+    this.endTime,
+    this.timeSetting = false,
+    @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+    this.createdAt,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    this.color = const Color(0xFF4285F4),
+  }) : super._();
+
+  factory _$CalendarEventImpl.fromJson(Map<String, dynamic> json) =>
+      _$$CalendarEventImplFromJson(json);
+
+  /// 클라이언트 식별용 ID (백엔드 ID 또는 자동 생성)
+  @override
+  final String id;
+
+  /// 사용자 ID
+  @override
+  final int usersId;
+
+  /// 일정 제목
+  @override
+  final String title;
+
+  /// 시작 날짜 (YYYY-MM-DD 형식)
+  @override
+  @JsonKey(name: 'startAt')
+  final String startAt;
+
+  /// 종료 날짜 (YYYY-MM-DD 형식)
+  @override
+  @JsonKey(name: 'endAt')
+  final String endAt;
+
+  /// 시작 시간 (HH:mm 형식, nullable)
+  @override
+  final String? startTime;
+
+  /// 종료 시간 (HH:mm 형식, nullable)
+  @override
+  final String? endTime;
+
+  /// 시간 설정 여부
+  @override
+  @JsonKey()
+  final bool timeSetting;
+
+  /// 생성 일시
+  @override
+  @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  final DateTime? createdAt;
+
+  /// 표시 색상 (클라이언트 전용, JSON 제외)
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  final Color color;
+
+  @override
+  String toString() {
+    return 'CalendarEvent(id: $id, usersId: $usersId, title: $title, startAt: $startAt, endAt: $endAt, startTime: $startTime, endTime: $endTime, timeSetting: $timeSetting, createdAt: $createdAt, color: $color)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$CalendarEventImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.usersId, usersId) || other.usersId == usersId) &&
+            (identical(other.title, title) || other.title == title) &&
+            (identical(other.startAt, startAt) || other.startAt == startAt) &&
+            (identical(other.endAt, endAt) || other.endAt == endAt) &&
+            (identical(other.startTime, startTime) ||
+                other.startTime == startTime) &&
+            (identical(other.endTime, endTime) || other.endTime == endTime) &&
+            (identical(other.timeSetting, timeSetting) ||
+                other.timeSetting == timeSetting) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.color, color) || other.color == color));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    id,
+    usersId,
+    title,
+    startAt,
+    endAt,
+    startTime,
+    endTime,
+    timeSetting,
+    createdAt,
+    color,
+  );
+
+  /// Create a copy of CalendarEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$CalendarEventImplCopyWith<_$CalendarEventImpl> get copyWith =>
+      __$$CalendarEventImplCopyWithImpl<_$CalendarEventImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$CalendarEventImplToJson(this);
+  }
+}
+
+abstract class _CalendarEvent extends CalendarEvent {
+  const factory _CalendarEvent({
+    required final String id,
+    required final int usersId,
+    required final String title,
+    @JsonKey(name: 'startAt') required final String startAt,
+    @JsonKey(name: 'endAt') required final String endAt,
+    final String? startTime,
+    final String? endTime,
+    final bool timeSetting,
+    @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+    final DateTime? createdAt,
+    @JsonKey(includeFromJson: false, includeToJson: false) final Color color,
+  }) = _$CalendarEventImpl;
+  const _CalendarEvent._() : super._();
+
+  factory _CalendarEvent.fromJson(Map<String, dynamic> json) =
+      _$CalendarEventImpl.fromJson;
+
+  /// 클라이언트 식별용 ID (백엔드 ID 또는 자동 생성)
+  @override
+  String get id;
+
+  /// 사용자 ID
+  @override
+  int get usersId;
+
+  /// 일정 제목
+  @override
+  String get title;
+
+  /// 시작 날짜 (YYYY-MM-DD 형식)
+  @override
+  @JsonKey(name: 'startAt')
+  String get startAt;
+
+  /// 종료 날짜 (YYYY-MM-DD 형식)
+  @override
+  @JsonKey(name: 'endAt')
+  String get endAt;
+
+  /// 시작 시간 (HH:mm 형식, nullable)
+  @override
+  String? get startTime;
+
+  /// 종료 시간 (HH:mm 형식, nullable)
+  @override
+  String? get endTime;
+
+  /// 시간 설정 여부
+  @override
+  bool get timeSetting;
+
+  /// 생성 일시
+  @override
+  @JsonKey(fromJson: _dateTimeFromJson, toJson: _dateTimeToJson)
+  DateTime? get createdAt;
+
+  /// 표시 색상 (클라이언트 전용, JSON 제외)
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  Color get color;
+
+  /// Create a copy of CalendarEvent
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$CalendarEventImplCopyWith<_$CalendarEventImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/models/calendar/calendar_event.g.dart
+++ b/lib/models/calendar/calendar_event.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'calendar_event.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$CalendarEventImpl _$$CalendarEventImplFromJson(Map<String, dynamic> json) =>
+    _$CalendarEventImpl(
+      id: json['id'] as String,
+      usersId: (json['usersId'] as num).toInt(),
+      title: json['title'] as String,
+      startAt: json['startAt'] as String,
+      endAt: json['endAt'] as String,
+      startTime: json['startTime'] as String?,
+      endTime: json['endTime'] as String?,
+      timeSetting: json['timeSetting'] as bool? ?? false,
+      createdAt: _dateTimeFromJson(json['createdAt'] as String?),
+    );
+
+Map<String, dynamic> _$$CalendarEventImplToJson(_$CalendarEventImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'usersId': instance.usersId,
+      'title': instance.title,
+      'startAt': instance.startAt,
+      'endAt': instance.endAt,
+      'startTime': instance.startTime,
+      'endTime': instance.endTime,
+      'timeSetting': instance.timeSetting,
+      'createdAt': _dateTimeToJson(instance.createdAt),
+    };

--- a/lib/views/screens/calendar_screen.dart
+++ b/lib/views/screens/calendar_screen.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../widgets/calendar/calendar_widget.dart';
+
+/// 캘린더 화면
+class CalendarScreen extends ConsumerWidget {
+  const CalendarScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.menu),
+          onPressed: () {
+            // TODO: 메뉴 열기
+          },
+        ),
+        title: const Text('캘린더'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () {
+              // TODO: 검색 기능
+            },
+          ),
+          Stack(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.notifications_outlined),
+                onPressed: () {
+                  // TODO: 알림 기능
+                },
+              ),
+              Positioned(
+                right: 8,
+                top: 8,
+                child: Container(
+                  width: 8,
+                  height: 8,
+                  decoration: const BoxDecoration(
+                    color: Colors.red,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: const CalendarWidget(),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: 1,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home_outlined),
+            activeIcon: Icon(Icons.home),
+            label: '',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_today_outlined),
+            activeIcon: Icon(Icons.calendar_today),
+            label: '',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.chat_bubble_outline),
+            activeIcon: Icon(Icons.chat_bubble),
+            label: '',
+          ),
+        ],
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+        onTap: (index) {
+          // TODO: 네비게이션 처리
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // TODO: 일정 추가
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/calendar/calendar_day_cell.dart
+++ b/lib/views/widgets/calendar/calendar_day_cell.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/calendar_utils.dart';
+
+/// 개별 날짜 셀 위젯
+class CalendarDayCell extends StatelessWidget {
+  const CalendarDayCell({
+    super.key,
+    required this.date,
+    required this.focusedMonth,
+    this.isSelected = false,
+    this.onTap,
+    this.eventWidgets = const [],
+    this.overflowCount = 0,
+  });
+
+  final DateTime date;
+  final DateTime focusedMonth;
+  final bool isSelected;
+  final VoidCallback? onTap;
+  final List<Widget> eventWidgets;
+  final int overflowCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final isCurrentMonth = CalendarUtils.isSameMonth(date, focusedMonth);
+    final isToday = CalendarUtils.isToday(date);
+    final isSunday = CalendarUtils.isSunday(date);
+    final isSaturday = CalendarUtils.isSaturday(date);
+
+    Color textColor = isCurrentMonth
+        ? Theme.of(context).colorScheme.onSurface
+        : Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.3);
+
+    if (isSunday && isCurrentMonth) {
+      textColor = AppTheme.sundayColor;
+    } else if (isSaturday && isCurrentMonth) {
+      textColor = AppTheme.saturdayColor;
+    }
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.all(1),
+        padding: const EdgeInsets.only(bottom: 4),
+        clipBehavior: Clip.hardEdge,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          color: isSelected
+              ? Colors.grey.withValues(alpha: 0.15)
+              : Colors.transparent,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // 날짜 숫자
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Center(
+                child: Container(
+                  width: 28,
+                  height: 28,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: isToday ? AppTheme.todayColor : null,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '${date.day}',
+                      style: TextStyle(
+                        color: isToday ? Colors.white : textColor,
+                        fontSize: 14,
+                        fontWeight: isToday ? FontWeight.bold : null,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            // 일정 표시 영역
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ...eventWidgets,
+                  if (overflowCount > 0)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 4, top: 1),
+                      child: Text(
+                        '+$overflowCount',
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: Colors.grey[600],
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/calendar/calendar_grid.dart
+++ b/lib/views/widgets/calendar/calendar_grid.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../controllers/calendar_controller.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/utils/calendar_utils.dart';
+import '../../../models/calendar/calendar_event.dart';
+import 'calendar_day_cell.dart';
+import 'event_chip.dart';
+
+/// 캘린더 그리드 위젯 (날짜 + 일정 표시)
+class CalendarGrid extends ConsumerWidget {
+  const CalendarGrid({
+    super.key,
+    required this.focusedMonth,
+    this.onDayTap,
+  });
+
+  final DateTime focusedMonth;
+  final void Function(DateTime)? onDayTap;
+
+  /// 표시할 최대 일정 수
+  static const int maxVisibleEvents = 3;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 해당 월의 이벤트 인덱스만 watch (월별 캐시됨)
+    final monthKey = getMonthKey(focusedMonth);
+    final eventIndex = ref.watch(eventIndexFamilyProvider(monthKey));
+    final days = CalendarUtils.getDaysInMonth(focusedMonth);
+
+    return Column(
+      children: [
+        // 요일 헤더
+        _buildWeekdayHeader(),
+        // 날짜 그리드
+        Expanded(
+          child: _buildDaysGrid(days, eventIndex),
+        ),
+      ],
+    );
+  }
+
+  /// 요일 헤더 위젯
+  Widget _buildWeekdayHeader() {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: List.generate(7, (index) {
+          Color textColor = Colors.grey[600]!;
+          if (index == 0) {
+            textColor = AppTheme.sundayColor;
+          } else if (index == 6) {
+            textColor = AppTheme.saturdayColor;
+          }
+
+          return Expanded(
+            child: Center(
+              child: Text(
+                CalendarUtils.weekdayHeaders[index],
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: textColor,
+                ),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  /// 날짜 그리드 위젯
+  Widget _buildDaysGrid(
+    List<DateTime> days,
+    CalendarEventIndex eventIndex,
+  ) {
+    // 주(week) 단위로 분할
+    final weeks = <List<DateTime>>[];
+    for (var i = 0; i < days.length; i += 7) {
+      weeks.add(days.sublist(i, i + 7));
+    }
+
+    return Column(
+      children: weeks
+          .map((week) => _buildWeekRow(week, eventIndex))
+          .toList(),
+    );
+  }
+
+  /// 주 단위 행 위젯
+  Widget _buildWeekRow(
+    List<DateTime> week,
+    CalendarEventIndex eventIndex,
+  ) {
+    return Expanded(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: week.asMap().entries.map((entry) {
+          final dayIndex = entry.key;
+          final date = entry.value;
+
+          return Expanded(
+            child: _OptimizedDayCell(
+              date: date,
+              dayIndex: dayIndex,
+              week: week,
+              focusedMonth: focusedMonth,
+              eventIndex: eventIndex,
+              onTap: () => onDayTap?.call(date),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+/// 최적화된 날짜 셀 (selectedDate만 watch)
+class _OptimizedDayCell extends ConsumerWidget {
+  const _OptimizedDayCell({
+    required this.date,
+    required this.dayIndex,
+    required this.week,
+    required this.focusedMonth,
+    required this.eventIndex,
+    this.onTap,
+  });
+
+  final DateTime date;
+  final int dayIndex;
+  final List<DateTime> week;
+  final DateTime focusedMonth;
+  final CalendarEventIndex eventIndex;
+  final VoidCallback? onTap;
+
+  static const int maxVisibleEvents = 3;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // selectedDate만 watch → 선택 변경 시 이 셀만 리빌드
+    final selectedDate = ref.watch(selectedDateProvider);
+    final isSelected =
+        selectedDate != null && CalendarUtils.isSameDay(date, selectedDate);
+
+    // O(1) 조회
+    final dayEvents = eventIndex.getEventsForDay(date);
+    final overflowCount = eventIndex.getOverflowCount(date);
+
+    // 일정 위젯 생성
+    final eventWidgets = _buildDayEventWidgets(dayEvents);
+
+    return CalendarDayCell(
+      date: date,
+      focusedMonth: focusedMonth,
+      isSelected: isSelected,
+      onTap: onTap,
+      eventWidgets: eventWidgets,
+      overflowCount: overflowCount,
+    );
+  }
+
+  /// 특정 날짜의 일정 위젯들 생성
+  List<Widget> _buildDayEventWidgets(List<CalendarEvent> dayEvents) {
+    if (dayEvents.isEmpty) return [];
+
+    final widgets = <Widget>[];
+    var lastSlot = -1;
+
+    for (var i = 0; i < dayEvents.length && i < maxVisibleEvents; i++) {
+      final event = dayEvents[i];
+      final slot = eventIndex.getSlot(event.id);
+
+      // 빈 슬롯 채우기
+      for (var s = lastSlot + 1;
+          s < slot && widgets.length < maxVisibleEvents;
+          s++) {
+        widgets.add(const SizedBox(height: 18));
+      }
+
+      if (widgets.length >= maxVisibleEvents) break;
+
+      lastSlot = slot;
+
+      // 일정의 시작/끝 여부 확인
+      final eventStart = DateTime(
+        event.startDate.year,
+        event.startDate.month,
+        event.startDate.day,
+      );
+      final eventEnd = DateTime(
+        event.endDate.year,
+        event.endDate.month,
+        event.endDate.day,
+      );
+      final currentDay = DateTime(date.year, date.month, date.day);
+      final weekStartDay = DateTime(
+        week.first.year,
+        week.first.month,
+        week.first.day,
+      );
+      final weekEndDay = DateTime(
+        week.last.year,
+        week.last.month,
+        week.last.day,
+      );
+
+      final isStart = CalendarUtils.isSameDay(eventStart, currentDay) ||
+          (CalendarUtils.isSameDay(weekStartDay, currentDay) &&
+              eventStart.isBefore(weekStartDay));
+      final isEnd = CalendarUtils.isSameDay(eventEnd, currentDay) ||
+          (CalendarUtils.isSameDay(weekEndDay, currentDay) &&
+              eventEnd.isAfter(weekEndDay));
+
+      // 시작일에만 제목 표시
+      final showTitle = CalendarUtils.isSameDay(eventStart, currentDay) ||
+          (dayIndex == 0 && eventStart.isBefore(weekStartDay));
+
+      widgets.add(
+        Padding(
+          padding: const EdgeInsets.only(top: 2),
+          child: EventChip(
+            event: event,
+            isStart: isStart,
+            isEnd: isEnd,
+            showTitle: showTitle,
+          ),
+        ),
+      );
+    }
+
+    return widgets;
+  }
+}

--- a/lib/views/widgets/calendar/calendar_header.dart
+++ b/lib/views/widgets/calendar/calendar_header.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/utils/calendar_utils.dart';
+
+/// 캘린더 헤더 위젯 (월/년 표시 및 네비게이션)
+class CalendarHeader extends StatelessWidget {
+  const CalendarHeader({
+    super.key,
+    required this.focusedMonth,
+    this.onMonthTap,
+  });
+
+  final DateTime focusedMonth;
+  final VoidCallback? onMonthTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          GestureDetector(
+            onTap: onMonthTap,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  CalendarUtils.formatMonth(focusedMonth),
+                  style: const TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                const Icon(Icons.keyboard_arrow_down, size: 20),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/calendar/calendar_widget.dart
+++ b/lib/views/widgets/calendar/calendar_widget.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../controllers/calendar_controller.dart';
+import 'calendar_grid.dart';
+import 'calendar_header.dart';
+
+/// 메인 캘린더 위젯
+class CalendarWidget extends ConsumerStatefulWidget {
+  const CalendarWidget({super.key});
+
+  @override
+  ConsumerState<CalendarWidget> createState() => _CalendarWidgetState();
+}
+
+class _CalendarWidgetState extends ConsumerState<CalendarWidget> {
+  late PageController _pageController;
+
+  /// 초기 페이지 인덱스 (무한 스크롤을 위한 중간값)
+  static const int _initialPage = 1000;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController(initialPage: _initialPage);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  /// 페이지 인덱스에서 월 계산
+  DateTime _getMonthFromPage(int pageIndex) {
+    final monthOffset = pageIndex - _initialPage;
+    final now = DateTime.now();
+    return DateTime(now.year, now.month + monthOffset, 1);
+  }
+
+  /// 월에서 페이지 인덱스 계산
+  int _getPageFromMonth(DateTime month) {
+    final now = DateTime.now();
+    final baseMonth = DateTime(now.year, now.month, 1);
+    final monthDiff =
+        (month.year - baseMonth.year) * 12 + (month.month - baseMonth.month);
+    return _initialPage + monthDiff;
+  }
+
+  /// 년/월 선택 Picker 표시
+  void _showYearMonthPicker(BuildContext context, DateTime currentMonth) {
+    var selectedYear = currentMonth.year;
+    var selectedMonth = currentMonth.month;
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return Dialog(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Container(
+                padding: const EdgeInsets.all(16),
+                height: 280,
+                child: Column(
+                  children: [
+                    Expanded(
+                      child: Row(
+                        children: [
+                          // 년 선택
+                          Expanded(
+                            child: ListWheelScrollView.useDelegate(
+                              itemExtent: 44,
+                              perspective: 0.005,
+                              diameterRatio: 1.5,
+                              physics: const FixedExtentScrollPhysics(),
+                              controller: FixedExtentScrollController(
+                                initialItem: selectedYear - 2020,
+                              ),
+                              onSelectedItemChanged: (index) {
+                                setDialogState(() {
+                                  selectedYear = 2020 + index;
+                                });
+                              },
+                              childDelegate: ListWheelChildBuilderDelegate(
+                                childCount: 20,
+                                builder: (context, index) {
+                                  final year = 2020 + index;
+                                  final isSelected = year == selectedYear;
+                                  return Center(
+                                    child: Text(
+                                      '$year년',
+                                      style: TextStyle(
+                                        fontSize: isSelected ? 20 : 16,
+                                        fontWeight: isSelected
+                                            ? FontWeight.bold
+                                            : FontWeight.normal,
+                                        color: isSelected
+                                            ? Colors.black
+                                            : Colors.grey,
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          ),
+                          // 월 선택
+                          Expanded(
+                            child: ListWheelScrollView.useDelegate(
+                              itemExtent: 44,
+                              perspective: 0.005,
+                              diameterRatio: 1.5,
+                              physics: const FixedExtentScrollPhysics(),
+                              controller: FixedExtentScrollController(
+                                initialItem: selectedMonth - 1,
+                              ),
+                              onSelectedItemChanged: (index) {
+                                setDialogState(() {
+                                  selectedMonth = index + 1;
+                                });
+                              },
+                              childDelegate: ListWheelChildBuilderDelegate(
+                                childCount: 12,
+                                builder: (context, index) {
+                                  final month = index + 1;
+                                  final isSelected = month == selectedMonth;
+                                  return Center(
+                                    child: Text(
+                                      '$month월',
+                                      style: TextStyle(
+                                        fontSize: isSelected ? 20 : 16,
+                                        fontWeight: isSelected
+                                            ? FontWeight.bold
+                                            : FontWeight.normal,
+                                        color: isSelected
+                                            ? Colors.black
+                                            : Colors.grey,
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    ).then((_) {
+      // 다이얼로그가 닫힐 때 월 이동 적용
+      final controller = ref.read(calendarProvider.notifier);
+      controller.goToMonth(DateTime(selectedYear, selectedMonth));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 헤더용 focusedMonth만 watch (선택적 구독)
+    final focusedMonth = ref.watch(
+      calendarProvider.select((s) => s.focusedMonth),
+    );
+    final calendarController = ref.read(calendarProvider.notifier);
+
+    // 외부에서 월이 변경되면 페이지도 이동 (Picker에서 선택 시)
+    ref.listen(
+      calendarProvider.select((s) => s.focusedMonth),
+      (previous, next) {
+        if (previous != next) {
+          final targetPage = _getPageFromMonth(next);
+          if (_pageController.hasClients &&
+              _pageController.page?.round() != targetPage) {
+            _pageController.animateToPage(
+              targetPage,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+            );
+          }
+        }
+      },
+    );
+
+    return Column(
+      children: [
+        // 헤더
+        CalendarHeader(
+          focusedMonth: focusedMonth,
+          onMonthTap: () {
+            _showYearMonthPicker(context, focusedMonth);
+          },
+        ),
+        // 캘린더 본체 (스와이프 가능)
+        Expanded(
+          child: PageView.builder(
+            controller: _pageController,
+            // 슬라이드 완료 후 헤더만 업데이트
+            onPageChanged: (page) {
+              final newMonth = _getMonthFromPage(page);
+              if (newMonth.year != focusedMonth.year ||
+                  newMonth.month != focusedMonth.month) {
+                // 비동기로 상태 업데이트 (UI 블로킹 방지)
+                Future.microtask(() {
+                  calendarController.goToMonth(newMonth);
+                });
+              }
+            },
+            itemBuilder: (context, index) {
+              final month = _getMonthFromPage(index);
+              return CalendarGrid(
+                focusedMonth: month,
+                onDayTap: (date) {
+                  calendarController.selectDate(date);
+                },
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/widgets/calendar/event_chip.dart
+++ b/lib/views/widgets/calendar/event_chip.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/calendar/calendar_event.dart';
+
+/// 일정 표시용 칩 위젯
+class EventChip extends StatelessWidget {
+  const EventChip({
+    super.key,
+    required this.event,
+    this.isStart = true,
+    this.isEnd = true,
+    this.showTitle = true,
+  });
+
+  final CalendarEvent event;
+  final bool isStart;
+  final bool isEnd;
+  final bool showTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 16,
+      margin: EdgeInsets.only(
+        left: isStart ? 2 : 0,
+        right: isEnd ? 2 : 0,
+      ),
+      decoration: BoxDecoration(
+        color: event.color.withValues(alpha: 0.8),
+        borderRadius: BorderRadius.horizontal(
+          left: isStart ? const Radius.circular(4) : Radius.zero,
+          right: isEnd ? const Radius.circular(4) : Radius.zero,
+        ),
+      ),
+      child: showTitle
+          ? Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                event.title,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w500,
+                ),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+              ),
+            )
+          : null,
+    );
+  }
+}

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - FlutterMacOS (1.0.0)
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
+
+EXTERNAL SOURCES:
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  sqflite_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin
+
+SPEC CHECKSUMS:
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		3237337BAA3B7FA78BE87BB3 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FC20131716D0D1B31616B01A /* Pods_RunnerTests.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		9B60DF5C58ED79D80CF39769 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7695D3673AD8A57A860AE8E0 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		27589F8A08C158FB0F3DADF4 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		305230FB98A3F90C3B919A90 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* poj_todo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "poj_todo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* poj_todo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = poj_todo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +80,14 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		7695D3673AD8A57A860AE8E0 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8ECFF8C387F4099F34541534 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		AF7485AC03D99631DA322426 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		B30D6563EAA5C4059C2B870C /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		F1C8AED26B7771F8B8892F76 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		FC20131716D0D1B31616B01A /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3237337BAA3B7FA78BE87BB3 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9B60DF5C58ED79D80CF39769 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				FE24CC9647DC697AB20246F7 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -175,8 +188,24 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7695D3673AD8A57A860AE8E0 /* Pods_Runner.framework */,
+				FC20131716D0D1B31616B01A /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FE24CC9647DC697AB20246F7 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				B30D6563EAA5C4059C2B870C /* Pods-Runner.debug.xcconfig */,
+				27589F8A08C158FB0F3DADF4 /* Pods-Runner.release.xcconfig */,
+				305230FB98A3F90C3B919A90 /* Pods-Runner.profile.xcconfig */,
+				8ECFF8C387F4099F34541534 /* Pods-RunnerTests.debug.xcconfig */,
+				F1C8AED26B7771F8B8892F76 /* Pods-RunnerTests.release.xcconfig */,
+				AF7485AC03D99631DA322426 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				D7407DCDE4B2C1065071E797 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				D4BAE46B490FBAB816FA61CF /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				8DC2D12EE2366724367C39BA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -329,6 +361,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		8DC2D12EE2366724367C39BA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D4BAE46B490FBAB816FA61CF /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D7407DCDE4B2C1065071E797 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8ECFF8C387F4099F34541534 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F1C8AED26B7771F8B8892F76 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = AF7485AC03D99631DA322426 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
- Riverpod(Notifier)로 캘린더 상태 관리 구조 추가
  - focusedMonth/selectedDate/events 상태 정의 및 월 이동/날짜 선택 API 제공
  - select/family provider로 리빌드 범위 최소화(선택 날짜/이벤트 목록/월 인덱스 분리)
- CalendarEvent 모델 도입(Freezed + JSON)
  - 날짜 범위/멀티데이/기간 계산 및 특정 날짜 포함 여부(occursOnDay) 제공
  - UI 전용 color 필드는 JSON 직렬화에서 제외
- 월 단위 이벤트 인덱싱/겹침 처리 추가
  - 주(week) 단위 슬롯 할당으로 겹치는 이벤트를 일정한 행(slot)에 배치
  - 날짜별 이벤트/오버플로우(+N) 계산 및 O(1) 조회 지원
- 캘린더 UI 추가(헤더/그리드/셀/이벤트 칩)
  - PageView 기반 월 스와이프 + 년/월 picker로 이동
  - 날짜 셀 선택 표시, 오늘 강조, 요일(일/토) 색상, 이벤트 칩(start/end 라운딩) 렌더링
- 앱 진입점/테마 정리
  - ProviderScope 적용 및 기본 홈을 CalendarScreen으로 설정
  - 캘린더 색상/이벤트 기본 팔레트 상수 추가
- 의존성/코드 생성 설정 반영
  - flutter_riverpod, freezed/json_serializable/build_runner 등 추가 및 generated 파일 포함
- iOS/macOS CocoaPods 설정 갱신
  - Podfile.lock 및 Xcode project/workspace 파일 업데이트(의존성 반영)

Test plan:
- flutter run 후 캘린더 화면 진입 확인
- 월 스와이프/년월 선택, 날짜 선택 시 하이라이트 반영 확인
- 멀티데이/겹침 이벤트 렌더링 및 +N 오버플로우 표기 확인
- iOS 빌드(pod install 반영) 확인