### PR TITLE
dev 병합

### DIFF
--- a/lib/models/dto/home_response_dto.dart
+++ b/lib/models/dto/home_response_dto.dart
@@ -12,11 +12,19 @@ bool _boolFromJson(dynamic value) {
   return false;
 }
 
+/// JSON에서 int 파싱 (null, num, String 지원)
+int _intFromJson(dynamic value) {
+  if (value == null) return 0;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}
+
 /// 홈 API 응답 DTO
 @freezed
 class HomeResponseDto with _$HomeResponseDto {
   const factory HomeResponseDto({
-    required int userId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int userId,
     @Default([]) List<FolderDto> folders,
     @Default([]) List<FolderViewDto> foldersViews,
     @Default([]) List<ScheduleDto> schedules,
@@ -30,8 +38,8 @@ class HomeResponseDto with _$HomeResponseDto {
 @freezed
 class FolderDto with _$FolderDto {
   const factory FolderDto({
-    required int foldersId,
-    required int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int foldersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
     @Default('') String name,
     @Default('') String memo,
     @JsonKey(fromJson: _boolFromJson) @Default(false) bool isDefault,
@@ -50,7 +58,7 @@ class FolderDto with _$FolderDto {
 @freezed
 class FolderViewDto with _$FolderViewDto {
   const factory FolderViewDto({
-    required int folderId,
+    @Default(0) int folderId,
     @Default('') String name,
     String? lastViewedAt,
   }) = _FolderViewDto;
@@ -63,7 +71,7 @@ class FolderViewDto with _$FolderViewDto {
 @freezed
 class ScheduleDto with _$ScheduleDto {
   const factory ScheduleDto({
-    required int schedulesId,
+    @Default(0) int schedulesId,
     @Default('') String title,
     String? startTime,
     String? endTime,

--- a/lib/models/dto/home_response_dto.freezed.dart
+++ b/lib/models/dto/home_response_dto.freezed.dart
@@ -21,6 +21,7 @@ HomeResponseDto _$HomeResponseDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$HomeResponseDto {
+  @JsonKey(fromJson: _intFromJson)
   int get userId => throw _privateConstructorUsedError;
   List<FolderDto> get folders => throw _privateConstructorUsedError;
   List<FolderViewDto> get foldersViews => throw _privateConstructorUsedError;
@@ -44,7 +45,7 @@ abstract class $HomeResponseDtoCopyWith<$Res> {
   ) = _$HomeResponseDtoCopyWithImpl<$Res, HomeResponseDto>;
   @useResult
   $Res call({
-    int userId,
+    @JsonKey(fromJson: _intFromJson) int userId,
     List<FolderDto> folders,
     List<FolderViewDto> foldersViews,
     List<ScheduleDto> schedules,
@@ -105,7 +106,7 @@ abstract class _$$HomeResponseDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int userId,
+    @JsonKey(fromJson: _intFromJson) int userId,
     List<FolderDto> folders,
     List<FolderViewDto> foldersViews,
     List<ScheduleDto> schedules,
@@ -158,7 +159,7 @@ class __$$HomeResponseDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$HomeResponseDtoImpl implements _HomeResponseDto {
   const _$HomeResponseDtoImpl({
-    required this.userId,
+    @JsonKey(fromJson: _intFromJson) this.userId = 0,
     final List<FolderDto> folders = const [],
     final List<FolderViewDto> foldersViews = const [],
     final List<ScheduleDto> schedules = const [],
@@ -170,6 +171,7 @@ class _$HomeResponseDtoImpl implements _HomeResponseDto {
       _$$HomeResponseDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int userId;
   final List<FolderDto> _folders;
   @override
@@ -249,7 +251,7 @@ class _$HomeResponseDtoImpl implements _HomeResponseDto {
 
 abstract class _HomeResponseDto implements HomeResponseDto {
   const factory _HomeResponseDto({
-    required final int userId,
+    @JsonKey(fromJson: _intFromJson) final int userId,
     final List<FolderDto> folders,
     final List<FolderViewDto> foldersViews,
     final List<ScheduleDto> schedules,
@@ -259,6 +261,7 @@ abstract class _HomeResponseDto implements HomeResponseDto {
       _$HomeResponseDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get userId;
   @override
   List<FolderDto> get folders;
@@ -281,7 +284,9 @@ FolderDto _$FolderDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$FolderDto {
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   String get memo => throw _privateConstructorUsedError;
@@ -309,8 +314,8 @@ abstract class $FolderDtoCopyWith<$Res> {
       _$FolderDtoCopyWithImpl<$Res, FolderDto>;
   @useResult
   $Res call({
-    int foldersId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String name,
     String memo,
     @JsonKey(fromJson: _boolFromJson) bool isDefault,
@@ -406,8 +411,8 @@ abstract class _$$FolderDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int foldersId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String name,
     String memo,
     @JsonKey(fromJson: _boolFromJson) bool isDefault,
@@ -495,8 +500,8 @@ class __$$FolderDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$FolderDtoImpl implements _FolderDto {
   const _$FolderDtoImpl({
-    required this.foldersId,
-    required this.usersId,
+    @JsonKey(fromJson: _intFromJson) this.foldersId = 0,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
     this.name = '',
     this.memo = '',
     @JsonKey(fromJson: _boolFromJson) this.isDefault = false,
@@ -511,8 +516,10 @@ class _$FolderDtoImpl implements _FolderDto {
       _$$FolderDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int foldersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
   @JsonKey()
@@ -597,8 +604,8 @@ class _$FolderDtoImpl implements _FolderDto {
 
 abstract class _FolderDto implements FolderDto {
   const factory _FolderDto({
-    required final int foldersId,
-    required final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int foldersId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
     final String name,
     final String memo,
     @JsonKey(fromJson: _boolFromJson) final bool isDefault,
@@ -613,8 +620,10 @@ abstract class _FolderDto implements FolderDto {
       _$FolderDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
   String get name;
@@ -764,7 +773,7 @@ class __$$FolderViewDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$FolderViewDtoImpl implements _FolderViewDto {
   const _$FolderViewDtoImpl({
-    required this.folderId,
+    this.folderId = 0,
     this.name = '',
     this.lastViewedAt,
   });
@@ -773,6 +782,7 @@ class _$FolderViewDtoImpl implements _FolderViewDto {
       _$$FolderViewDtoImplFromJson(json);
 
   @override
+  @JsonKey()
   final int folderId;
   @override
   @JsonKey()
@@ -817,7 +827,7 @@ class _$FolderViewDtoImpl implements _FolderViewDto {
 
 abstract class _FolderViewDto implements FolderViewDto {
   const factory _FolderViewDto({
-    required final int folderId,
+    final int folderId,
     final String name,
     final String? lastViewedAt,
   }) = _$FolderViewDtoImpl;
@@ -996,7 +1006,7 @@ class __$$ScheduleDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$ScheduleDtoImpl implements _ScheduleDto {
   const _$ScheduleDtoImpl({
-    required this.schedulesId,
+    this.schedulesId = 0,
     this.title = '',
     this.startTime,
     this.endTime,
@@ -1007,6 +1017,7 @@ class _$ScheduleDtoImpl implements _ScheduleDto {
       _$$ScheduleDtoImplFromJson(json);
 
   @override
+  @JsonKey()
   final int schedulesId;
   @override
   @JsonKey()
@@ -1066,7 +1077,7 @@ class _$ScheduleDtoImpl implements _ScheduleDto {
 
 abstract class _ScheduleDto implements ScheduleDto {
   const factory _ScheduleDto({
-    required final int schedulesId,
+    final int schedulesId,
     final String title,
     final String? startTime,
     final String? endTime,

--- a/lib/models/dto/home_response_dto.g.dart
+++ b/lib/models/dto/home_response_dto.g.dart
@@ -9,7 +9,7 @@ part of 'home_response_dto.dart';
 _$HomeResponseDtoImpl _$$HomeResponseDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$HomeResponseDtoImpl(
-  userId: (json['userId'] as num).toInt(),
+  userId: json['userId'] == null ? 0 : _intFromJson(json['userId']),
   folders:
       (json['folders'] as List<dynamic>?)
           ?.map((e) => FolderDto.fromJson(e as Map<String, dynamic>))
@@ -38,8 +38,10 @@ Map<String, dynamic> _$$HomeResponseDtoImplToJson(
 
 _$FolderDtoImpl _$$FolderDtoImplFromJson(Map<String, dynamic> json) =>
     _$FolderDtoImpl(
-      foldersId: (json['foldersId'] as num).toInt(),
-      usersId: (json['usersId'] as num).toInt(),
+      foldersId: json['foldersId'] == null
+          ? 0
+          : _intFromJson(json['foldersId']),
+      usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
       name: json['name'] as String? ?? '',
       memo: json['memo'] as String? ?? '',
       isDefault: json['isDefault'] == null
@@ -68,7 +70,7 @@ Map<String, dynamic> _$$FolderDtoImplToJson(_$FolderDtoImpl instance) =>
 
 _$FolderViewDtoImpl _$$FolderViewDtoImplFromJson(Map<String, dynamic> json) =>
     _$FolderViewDtoImpl(
-      folderId: (json['folderId'] as num).toInt(),
+      folderId: (json['folderId'] as num?)?.toInt() ?? 0,
       name: json['name'] as String? ?? '',
       lastViewedAt: json['lastViewedAt'] as String?,
     );
@@ -82,7 +84,7 @@ Map<String, dynamic> _$$FolderViewDtoImplToJson(_$FolderViewDtoImpl instance) =>
 
 _$ScheduleDtoImpl _$$ScheduleDtoImplFromJson(Map<String, dynamic> json) =>
     _$ScheduleDtoImpl(
-      schedulesId: (json['schedulesId'] as num).toInt(),
+      schedulesId: (json['schedulesId'] as num?)?.toInt() ?? 0,
       title: json['title'] as String? ?? '',
       startTime: json['startTime'] as String?,
       endTime: json['endTime'] as String?,

--- a/lib/models/dto/page_items_response_dto.dart
+++ b/lib/models/dto/page_items_response_dto.dart
@@ -3,12 +3,20 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'page_items_response_dto.freezed.dart';
 part 'page_items_response_dto.g.dart';
 
+/// JSON에서 int 파싱 (null, num, String 지원)
+int _intFromJson(dynamic value) {
+  if (value == null) return 0;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}
+
 /// GET /page/items 응답 DTO (보관함 내부 - 링크/노트/파일/이미지)
 @freezed
 class PageItemsResponseDto with _$PageItemsResponseDto {
   const factory PageItemsResponseDto({
-    required int usersId,
-    required int foldersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int foldersId,
     @Default([]) List<LinkDto> links,
     @Default([]) List<TextDto> texts,
     @Default([]) List<AttachmentFileDto> files,
@@ -23,7 +31,7 @@ class PageItemsResponseDto with _$PageItemsResponseDto {
 @freezed
 class TextDto with _$TextDto {
   const factory TextDto({
-    required int textsId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int textsId,
     @Default('') String textContent,
     String? createdAt,
   }) = _TextDto;
@@ -36,7 +44,7 @@ class TextDto with _$TextDto {
 @freezed
 class LinkDto with _$LinkDto {
   const factory LinkDto({
-    required int linksId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int linksId,
     @Default('') String linksName,
     @Default('') String linksUrl,
     @Default('') String linksThumbnail,
@@ -52,8 +60,8 @@ class LinkDto with _$LinkDto {
 @freezed
 class AttachmentFileDto with _$AttachmentFileDto {
   const factory AttachmentFileDto({
-    required int attachmentsId,
-    required int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
     @Default('') String attachmentsType,
     @Default('') String objectKey,
     @Default('') String presignedUrl,
@@ -71,8 +79,8 @@ class AttachmentFileDto with _$AttachmentFileDto {
 @freezed
 class AttachmentImageDto with _$AttachmentImageDto {
   const factory AttachmentImageDto({
-    required int attachmentsId,
-    required int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
     @Default('') String attachmentsType,
     @Default('') String objectKey,
     @Default('') String presignedUrl,

--- a/lib/models/dto/page_items_response_dto.freezed.dart
+++ b/lib/models/dto/page_items_response_dto.freezed.dart
@@ -21,7 +21,9 @@ PageItemsResponseDto _$PageItemsResponseDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$PageItemsResponseDto {
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId => throw _privateConstructorUsedError;
   List<LinkDto> get links => throw _privateConstructorUsedError;
   List<TextDto> get texts => throw _privateConstructorUsedError;
@@ -46,8 +48,8 @@ abstract class $PageItemsResponseDtoCopyWith<$Res> {
   ) = _$PageItemsResponseDtoCopyWithImpl<$Res, PageItemsResponseDto>;
   @useResult
   $Res call({
-    int usersId,
-    int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
     List<LinkDto> links,
     List<TextDto> texts,
     List<AttachmentFileDto> files,
@@ -122,8 +124,8 @@ abstract class _$$PageItemsResponseDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int usersId,
-    int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
     List<LinkDto> links,
     List<TextDto> texts,
     List<AttachmentFileDto> files,
@@ -187,8 +189,8 @@ class __$$PageItemsResponseDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$PageItemsResponseDtoImpl implements _PageItemsResponseDto {
   const _$PageItemsResponseDtoImpl({
-    required this.usersId,
-    required this.foldersId,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
+    @JsonKey(fromJson: _intFromJson) this.foldersId = 0,
     final List<LinkDto> links = const [],
     final List<TextDto> texts = const [],
     final List<AttachmentFileDto> files = const [],
@@ -202,8 +204,10 @@ class _$PageItemsResponseDtoImpl implements _PageItemsResponseDto {
       _$$PageItemsResponseDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int foldersId;
   final List<LinkDto> _links;
   @override
@@ -292,8 +296,8 @@ class _$PageItemsResponseDtoImpl implements _PageItemsResponseDto {
 
 abstract class _PageItemsResponseDto implements PageItemsResponseDto {
   const factory _PageItemsResponseDto({
-    required final int usersId,
-    required final int foldersId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int foldersId,
     final List<LinkDto> links,
     final List<TextDto> texts,
     final List<AttachmentFileDto> files,
@@ -304,8 +308,10 @@ abstract class _PageItemsResponseDto implements PageItemsResponseDto {
       _$PageItemsResponseDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId;
   @override
   List<LinkDto> get links;
@@ -330,6 +336,7 @@ TextDto _$TextDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$TextDto {
+  @JsonKey(fromJson: _intFromJson)
   int get textsId => throw _privateConstructorUsedError;
   String get textContent => throw _privateConstructorUsedError;
   String? get createdAt => throw _privateConstructorUsedError;
@@ -348,7 +355,11 @@ abstract class $TextDtoCopyWith<$Res> {
   factory $TextDtoCopyWith(TextDto value, $Res Function(TextDto) then) =
       _$TextDtoCopyWithImpl<$Res, TextDto>;
   @useResult
-  $Res call({int textsId, String textContent, String? createdAt});
+  $Res call({
+    @JsonKey(fromJson: _intFromJson) int textsId,
+    String textContent,
+    String? createdAt,
+  });
 }
 
 /// @nodoc
@@ -398,7 +409,11 @@ abstract class _$$TextDtoImplCopyWith<$Res> implements $TextDtoCopyWith<$Res> {
   ) = __$$TextDtoImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int textsId, String textContent, String? createdAt});
+  $Res call({
+    @JsonKey(fromJson: _intFromJson) int textsId,
+    String textContent,
+    String? createdAt,
+  });
 }
 
 /// @nodoc
@@ -442,7 +457,7 @@ class __$$TextDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$TextDtoImpl implements _TextDto {
   const _$TextDtoImpl({
-    required this.textsId,
+    @JsonKey(fromJson: _intFromJson) this.textsId = 0,
     this.textContent = '',
     this.createdAt,
   });
@@ -451,6 +466,7 @@ class _$TextDtoImpl implements _TextDto {
       _$$TextDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int textsId;
   @override
   @JsonKey()
@@ -495,7 +511,7 @@ class _$TextDtoImpl implements _TextDto {
 
 abstract class _TextDto implements TextDto {
   const factory _TextDto({
-    required final int textsId,
+    @JsonKey(fromJson: _intFromJson) final int textsId,
     final String textContent,
     final String? createdAt,
   }) = _$TextDtoImpl;
@@ -503,6 +519,7 @@ abstract class _TextDto implements TextDto {
   factory _TextDto.fromJson(Map<String, dynamic> json) = _$TextDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get textsId;
   @override
   String get textContent;
@@ -523,6 +540,7 @@ LinkDto _$LinkDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$LinkDto {
+  @JsonKey(fromJson: _intFromJson)
   int get linksId => throw _privateConstructorUsedError;
   String get linksName => throw _privateConstructorUsedError;
   String get linksUrl => throw _privateConstructorUsedError;
@@ -545,7 +563,7 @@ abstract class $LinkDtoCopyWith<$Res> {
       _$LinkDtoCopyWithImpl<$Res, LinkDto>;
   @useResult
   $Res call({
-    int linksId,
+    @JsonKey(fromJson: _intFromJson) int linksId,
     String linksName,
     String linksUrl,
     String linksThumbnail,
@@ -617,7 +635,7 @@ abstract class _$$LinkDtoImplCopyWith<$Res> implements $LinkDtoCopyWith<$Res> {
   @override
   @useResult
   $Res call({
-    int linksId,
+    @JsonKey(fromJson: _intFromJson) int linksId,
     String linksName,
     String linksUrl,
     String linksThumbnail,
@@ -682,7 +700,7 @@ class __$$LinkDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$LinkDtoImpl implements _LinkDto {
   const _$LinkDtoImpl({
-    required this.linksId,
+    @JsonKey(fromJson: _intFromJson) this.linksId = 0,
     this.linksName = '',
     this.linksUrl = '',
     this.linksThumbnail = '',
@@ -694,6 +712,7 @@ class _$LinkDtoImpl implements _LinkDto {
       _$$LinkDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int linksId;
   @override
   @JsonKey()
@@ -761,7 +780,7 @@ class _$LinkDtoImpl implements _LinkDto {
 
 abstract class _LinkDto implements LinkDto {
   const factory _LinkDto({
-    required final int linksId,
+    @JsonKey(fromJson: _intFromJson) final int linksId,
     final String linksName,
     final String linksUrl,
     final String linksThumbnail,
@@ -772,6 +791,7 @@ abstract class _LinkDto implements LinkDto {
   factory _LinkDto.fromJson(Map<String, dynamic> json) = _$LinkDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get linksId;
   @override
   String get linksName;
@@ -798,7 +818,9 @@ AttachmentFileDto _$AttachmentFileDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$AttachmentFileDto {
+  @JsonKey(fromJson: _intFromJson)
   int get attachmentsId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
   String get attachmentsType => throw _privateConstructorUsedError;
   String get objectKey => throw _privateConstructorUsedError;
@@ -826,8 +848,8 @@ abstract class $AttachmentFileDtoCopyWith<$Res> {
   ) = _$AttachmentFileDtoCopyWithImpl<$Res, AttachmentFileDto>;
   @useResult
   $Res call({
-    int attachmentsId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String attachmentsType,
     String objectKey,
     String presignedUrl,
@@ -917,8 +939,8 @@ abstract class _$$AttachmentFileDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int attachmentsId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String attachmentsType,
     String objectKey,
     String presignedUrl,
@@ -1000,8 +1022,8 @@ class __$$AttachmentFileDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$AttachmentFileDtoImpl implements _AttachmentFileDto {
   const _$AttachmentFileDtoImpl({
-    required this.attachmentsId,
-    required this.usersId,
+    @JsonKey(fromJson: _intFromJson) this.attachmentsId = 0,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
     this.attachmentsType = '',
     this.objectKey = '',
     this.presignedUrl = '',
@@ -1015,8 +1037,10 @@ class _$AttachmentFileDtoImpl implements _AttachmentFileDto {
       _$$AttachmentFileDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int attachmentsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
   @JsonKey()
@@ -1102,8 +1126,8 @@ class _$AttachmentFileDtoImpl implements _AttachmentFileDto {
 
 abstract class _AttachmentFileDto implements AttachmentFileDto {
   const factory _AttachmentFileDto({
-    required final int attachmentsId,
-    required final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
     final String attachmentsType,
     final String objectKey,
     final String presignedUrl,
@@ -1117,8 +1141,10 @@ abstract class _AttachmentFileDto implements AttachmentFileDto {
       _$AttachmentFileDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get attachmentsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
   String get attachmentsType;
@@ -1149,7 +1175,9 @@ AttachmentImageDto _$AttachmentImageDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$AttachmentImageDto {
+  @JsonKey(fromJson: _intFromJson)
   int get attachmentsId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
   String get attachmentsType => throw _privateConstructorUsedError;
   String get objectKey => throw _privateConstructorUsedError;
@@ -1179,8 +1207,8 @@ abstract class $AttachmentImageDtoCopyWith<$Res> {
   ) = _$AttachmentImageDtoCopyWithImpl<$Res, AttachmentImageDto>;
   @useResult
   $Res call({
-    int attachmentsId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String attachmentsType,
     String objectKey,
     String presignedUrl,
@@ -1282,8 +1310,8 @@ abstract class _$$AttachmentImageDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int attachmentsId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String attachmentsType,
     String objectKey,
     String presignedUrl,
@@ -1377,8 +1405,8 @@ class __$$AttachmentImageDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$AttachmentImageDtoImpl implements _AttachmentImageDto {
   const _$AttachmentImageDtoImpl({
-    required this.attachmentsId,
-    required this.usersId,
+    @JsonKey(fromJson: _intFromJson) this.attachmentsId = 0,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
     this.attachmentsType = '',
     this.objectKey = '',
     this.presignedUrl = '',
@@ -1394,8 +1422,10 @@ class _$AttachmentImageDtoImpl implements _AttachmentImageDto {
       _$$AttachmentImageDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int attachmentsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
   @JsonKey()
@@ -1493,8 +1523,8 @@ class _$AttachmentImageDtoImpl implements _AttachmentImageDto {
 
 abstract class _AttachmentImageDto implements AttachmentImageDto {
   const factory _AttachmentImageDto({
-    required final int attachmentsId,
-    required final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
     final String attachmentsType,
     final String objectKey,
     final String presignedUrl,
@@ -1510,8 +1540,10 @@ abstract class _AttachmentImageDto implements AttachmentImageDto {
       _$AttachmentImageDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get attachmentsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
   String get attachmentsType;

--- a/lib/models/dto/page_items_response_dto.g.dart
+++ b/lib/models/dto/page_items_response_dto.g.dart
@@ -9,8 +9,8 @@ part of 'page_items_response_dto.dart';
 _$PageItemsResponseDtoImpl _$$PageItemsResponseDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$PageItemsResponseDtoImpl(
-  usersId: (json['usersId'] as num).toInt(),
-  foldersId: (json['foldersId'] as num).toInt(),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
+  foldersId: json['foldersId'] == null ? 0 : _intFromJson(json['foldersId']),
   links:
       (json['links'] as List<dynamic>?)
           ?.map((e) => LinkDto.fromJson(e as Map<String, dynamic>))
@@ -46,7 +46,7 @@ Map<String, dynamic> _$$PageItemsResponseDtoImplToJson(
 
 _$TextDtoImpl _$$TextDtoImplFromJson(Map<String, dynamic> json) =>
     _$TextDtoImpl(
-      textsId: (json['textsId'] as num).toInt(),
+      textsId: json['textsId'] == null ? 0 : _intFromJson(json['textsId']),
       textContent: json['textContent'] as String? ?? '',
       createdAt: json['createdAt'] as String?,
     );
@@ -60,7 +60,7 @@ Map<String, dynamic> _$$TextDtoImplToJson(_$TextDtoImpl instance) =>
 
 _$LinkDtoImpl _$$LinkDtoImplFromJson(Map<String, dynamic> json) =>
     _$LinkDtoImpl(
-      linksId: (json['linksId'] as num).toInt(),
+      linksId: json['linksId'] == null ? 0 : _intFromJson(json['linksId']),
       linksName: json['linksName'] as String? ?? '',
       linksUrl: json['linksUrl'] as String? ?? '',
       linksThumbnail: json['linksThumbnail'] as String? ?? '',
@@ -81,8 +81,10 @@ Map<String, dynamic> _$$LinkDtoImplToJson(_$LinkDtoImpl instance) =>
 _$AttachmentFileDtoImpl _$$AttachmentFileDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$AttachmentFileDtoImpl(
-  attachmentsId: (json['attachmentsId'] as num).toInt(),
-  usersId: (json['usersId'] as num).toInt(),
+  attachmentsId: json['attachmentsId'] == null
+      ? 0
+      : _intFromJson(json['attachmentsId']),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
   attachmentsType: json['attachmentsType'] as String? ?? '',
   objectKey: json['objectKey'] as String? ?? '',
   presignedUrl: json['presignedUrl'] as String? ?? '',
@@ -109,8 +111,10 @@ Map<String, dynamic> _$$AttachmentFileDtoImplToJson(
 _$AttachmentImageDtoImpl _$$AttachmentImageDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$AttachmentImageDtoImpl(
-  attachmentsId: (json['attachmentsId'] as num).toInt(),
-  usersId: (json['usersId'] as num).toInt(),
+  attachmentsId: json['attachmentsId'] == null
+      ? 0
+      : _intFromJson(json['attachmentsId']),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
   attachmentsType: json['attachmentsType'] as String? ?? '',
   objectKey: json['objectKey'] as String? ?? '',
   presignedUrl: json['presignedUrl'] as String? ?? '',

--- a/lib/models/dto/search_response_dto.dart
+++ b/lib/models/dto/search_response_dto.dart
@@ -12,6 +12,14 @@ bool _boolFromJson(dynamic value) {
   return false;
 }
 
+/// JSON에서 int 파싱 (null, num, String 지원)
+int _intFromJson(dynamic value) {
+  if (value == null) return 0;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
+}
+
 /// 통합 검색 API 응답 (GET /page/search)
 @freezed
 class SearchResponseDto with _$SearchResponseDto {
@@ -31,8 +39,8 @@ class SearchResponseDto with _$SearchResponseDto {
 @freezed
 class SearchFolderItemDto with _$SearchFolderItemDto {
   const factory SearchFolderItemDto({
-    required int foldersId,
-    required int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int foldersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
     @Default('') String name,
     @Default('') String memo,
     @JsonKey(fromJson: _boolFromJson) @Default(false) bool isDefault,
@@ -50,8 +58,8 @@ class SearchFolderItemDto with _$SearchFolderItemDto {
 @freezed
 class SearchScheduleItemDto with _$SearchScheduleItemDto {
   const factory SearchScheduleItemDto({
-    required int usersId,
-    required int schedulesId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int schedulesId,
     @Default('') String title,
     @Default(0) int foldersId,
     @Default('') String foldersTitle,
@@ -73,9 +81,9 @@ class SearchScheduleItemDto with _$SearchScheduleItemDto {
 @freezed
 class SearchLinkItemDto with _$SearchLinkItemDto {
   const factory SearchLinkItemDto({
-    required int linksId,
-    required int foldersId,
-    required int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int linksId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int foldersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
     @Default('') String linksName,
     @Default('') String linksUrl,
     @Default('') String linksThumbnail,
@@ -91,9 +99,9 @@ class SearchLinkItemDto with _$SearchLinkItemDto {
 @freezed
 class SearchTextItemDto with _$SearchTextItemDto {
   const factory SearchTextItemDto({
-    required int textsId,
-    required int usersId,
-    required int foldersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int textsId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int foldersId,
     @Default('') String textContent,
     String? createdAt,
   }) = _SearchTextItemDto;
@@ -106,9 +114,9 @@ class SearchTextItemDto with _$SearchTextItemDto {
 @freezed
 class SearchFileItemDto with _$SearchFileItemDto {
   const factory SearchFileItemDto({
-    required int attachmentsId,
-    required int usersId,
-    required int foldersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int usersId,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int foldersId,
     @Default('') String attachmentsType,
     @Default('') String objectKey,
     @Default('') String presignedUrl,

--- a/lib/models/dto/search_response_dto.freezed.dart
+++ b/lib/models/dto/search_response_dto.freezed.dart
@@ -316,7 +316,9 @@ SearchFolderItemDto _$SearchFolderItemDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$SearchFolderItemDto {
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   String get memo => throw _privateConstructorUsedError;
@@ -346,8 +348,8 @@ abstract class $SearchFolderItemDtoCopyWith<$Res> {
   ) = _$SearchFolderItemDtoCopyWithImpl<$Res, SearchFolderItemDto>;
   @useResult
   $Res call({
-    int foldersId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String name,
     String memo,
     @JsonKey(fromJson: _boolFromJson) bool isDefault,
@@ -437,8 +439,8 @@ abstract class _$$SearchFolderItemDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int foldersId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String name,
     String memo,
     @JsonKey(fromJson: _boolFromJson) bool isDefault,
@@ -520,8 +522,8 @@ class __$$SearchFolderItemDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$SearchFolderItemDtoImpl implements _SearchFolderItemDto {
   const _$SearchFolderItemDtoImpl({
-    required this.foldersId,
-    required this.usersId,
+    @JsonKey(fromJson: _intFromJson) this.foldersId = 0,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
     this.name = '',
     this.memo = '',
     @JsonKey(fromJson: _boolFromJson) this.isDefault = false,
@@ -535,8 +537,10 @@ class _$SearchFolderItemDtoImpl implements _SearchFolderItemDto {
       _$$SearchFolderItemDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int foldersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
   @JsonKey()
@@ -618,8 +622,8 @@ class _$SearchFolderItemDtoImpl implements _SearchFolderItemDto {
 
 abstract class _SearchFolderItemDto implements SearchFolderItemDto {
   const factory _SearchFolderItemDto({
-    required final int foldersId,
-    required final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int foldersId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
     final String name,
     final String memo,
     @JsonKey(fromJson: _boolFromJson) final bool isDefault,
@@ -633,8 +637,10 @@ abstract class _SearchFolderItemDto implements SearchFolderItemDto {
       _$SearchFolderItemDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
   String get name;
@@ -669,7 +675,9 @@ SearchScheduleItemDto _$SearchScheduleItemDtoFromJson(
 
 /// @nodoc
 mixin _$SearchScheduleItemDto {
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get schedulesId => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   int get foldersId => throw _privateConstructorUsedError;
@@ -701,8 +709,8 @@ abstract class $SearchScheduleItemDtoCopyWith<$Res> {
   ) = _$SearchScheduleItemDtoCopyWithImpl<$Res, SearchScheduleItemDto>;
   @useResult
   $Res call({
-    int usersId,
-    int schedulesId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int schedulesId,
     String title,
     int foldersId,
     String foldersTitle,
@@ -819,8 +827,8 @@ abstract class _$$SearchScheduleItemDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int usersId,
-    int schedulesId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int schedulesId,
     String title,
     int foldersId,
     String foldersTitle,
@@ -927,8 +935,8 @@ class __$$SearchScheduleItemDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$SearchScheduleItemDtoImpl implements _SearchScheduleItemDto {
   const _$SearchScheduleItemDtoImpl({
-    required this.usersId,
-    required this.schedulesId,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
+    @JsonKey(fromJson: _intFromJson) this.schedulesId = 0,
     this.title = '',
     this.foldersId = 0,
     this.foldersTitle = '',
@@ -946,8 +954,10 @@ class _$SearchScheduleItemDtoImpl implements _SearchScheduleItemDto {
       _$$SearchScheduleItemDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int schedulesId;
   @override
   @JsonKey()
@@ -1053,8 +1063,8 @@ class _$SearchScheduleItemDtoImpl implements _SearchScheduleItemDto {
 
 abstract class _SearchScheduleItemDto implements SearchScheduleItemDto {
   const factory _SearchScheduleItemDto({
-    required final int usersId,
-    required final int schedulesId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int schedulesId,
     final String title,
     final int foldersId,
     final String foldersTitle,
@@ -1072,8 +1082,10 @@ abstract class _SearchScheduleItemDto implements SearchScheduleItemDto {
       _$SearchScheduleItemDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get schedulesId;
   @override
   String get title;
@@ -1112,8 +1124,11 @@ SearchLinkItemDto _$SearchLinkItemDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$SearchLinkItemDto {
+  @JsonKey(fromJson: _intFromJson)
   int get linksId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
   String get linksName => throw _privateConstructorUsedError;
   String get linksUrl => throw _privateConstructorUsedError;
@@ -1139,9 +1154,9 @@ abstract class $SearchLinkItemDtoCopyWith<$Res> {
   ) = _$SearchLinkItemDtoCopyWithImpl<$Res, SearchLinkItemDto>;
   @useResult
   $Res call({
-    int linksId,
-    int foldersId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int linksId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String linksName,
     String linksUrl,
     String linksThumbnail,
@@ -1224,9 +1239,9 @@ abstract class _$$SearchLinkItemDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int linksId,
-    int foldersId,
-    int usersId,
+    @JsonKey(fromJson: _intFromJson) int linksId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
     String linksName,
     String linksUrl,
     String linksThumbnail,
@@ -1301,9 +1316,9 @@ class __$$SearchLinkItemDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$SearchLinkItemDtoImpl implements _SearchLinkItemDto {
   const _$SearchLinkItemDtoImpl({
-    required this.linksId,
-    required this.foldersId,
-    required this.usersId,
+    @JsonKey(fromJson: _intFromJson) this.linksId = 0,
+    @JsonKey(fromJson: _intFromJson) this.foldersId = 0,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
     this.linksName = '',
     this.linksUrl = '',
     this.linksThumbnail = '',
@@ -1315,10 +1330,13 @@ class _$SearchLinkItemDtoImpl implements _SearchLinkItemDto {
       _$$SearchLinkItemDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int linksId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int foldersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
   @JsonKey()
@@ -1394,9 +1412,9 @@ class _$SearchLinkItemDtoImpl implements _SearchLinkItemDto {
 
 abstract class _SearchLinkItemDto implements SearchLinkItemDto {
   const factory _SearchLinkItemDto({
-    required final int linksId,
-    required final int foldersId,
-    required final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int linksId,
+    @JsonKey(fromJson: _intFromJson) final int foldersId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
     final String linksName,
     final String linksUrl,
     final String linksThumbnail,
@@ -1408,10 +1426,13 @@ abstract class _SearchLinkItemDto implements SearchLinkItemDto {
       _$SearchLinkItemDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get linksId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
   String get linksName;
@@ -1438,8 +1459,11 @@ SearchTextItemDto _$SearchTextItemDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$SearchTextItemDto {
+  @JsonKey(fromJson: _intFromJson)
   int get textsId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId => throw _privateConstructorUsedError;
   String get textContent => throw _privateConstructorUsedError;
   String? get createdAt => throw _privateConstructorUsedError;
@@ -1462,9 +1486,9 @@ abstract class $SearchTextItemDtoCopyWith<$Res> {
   ) = _$SearchTextItemDtoCopyWithImpl<$Res, SearchTextItemDto>;
   @useResult
   $Res call({
-    int textsId,
-    int usersId,
-    int foldersId,
+    @JsonKey(fromJson: _intFromJson) int textsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
     String textContent,
     String? createdAt,
   });
@@ -1529,9 +1553,9 @@ abstract class _$$SearchTextItemDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int textsId,
-    int usersId,
-    int foldersId,
+    @JsonKey(fromJson: _intFromJson) int textsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
     String textContent,
     String? createdAt,
   });
@@ -1588,9 +1612,9 @@ class __$$SearchTextItemDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$SearchTextItemDtoImpl implements _SearchTextItemDto {
   const _$SearchTextItemDtoImpl({
-    required this.textsId,
-    required this.usersId,
-    required this.foldersId,
+    @JsonKey(fromJson: _intFromJson) this.textsId = 0,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
+    @JsonKey(fromJson: _intFromJson) this.foldersId = 0,
     this.textContent = '',
     this.createdAt,
   });
@@ -1599,10 +1623,13 @@ class _$SearchTextItemDtoImpl implements _SearchTextItemDto {
       _$$SearchTextItemDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int textsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int foldersId;
   @override
   @JsonKey()
@@ -1660,9 +1687,9 @@ class _$SearchTextItemDtoImpl implements _SearchTextItemDto {
 
 abstract class _SearchTextItemDto implements SearchTextItemDto {
   const factory _SearchTextItemDto({
-    required final int textsId,
-    required final int usersId,
-    required final int foldersId,
+    @JsonKey(fromJson: _intFromJson) final int textsId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int foldersId,
     final String textContent,
     final String? createdAt,
   }) = _$SearchTextItemDtoImpl;
@@ -1671,10 +1698,13 @@ abstract class _SearchTextItemDto implements SearchTextItemDto {
       _$SearchTextItemDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get textsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId;
   @override
   String get textContent;
@@ -1695,8 +1725,11 @@ SearchFileItemDto _$SearchFileItemDtoFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$SearchFileItemDto {
+  @JsonKey(fromJson: _intFromJson)
   int get attachmentsId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get usersId => throw _privateConstructorUsedError;
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId => throw _privateConstructorUsedError;
   String get attachmentsType => throw _privateConstructorUsedError;
   String get objectKey => throw _privateConstructorUsedError;
@@ -1724,9 +1757,9 @@ abstract class $SearchFileItemDtoCopyWith<$Res> {
   ) = _$SearchFileItemDtoCopyWithImpl<$Res, SearchFileItemDto>;
   @useResult
   $Res call({
-    int attachmentsId,
-    int usersId,
-    int foldersId,
+    @JsonKey(fromJson: _intFromJson) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
     String attachmentsType,
     String objectKey,
     String presignedUrl,
@@ -1821,9 +1854,9 @@ abstract class _$$SearchFileItemDtoImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int attachmentsId,
-    int usersId,
-    int foldersId,
+    @JsonKey(fromJson: _intFromJson) int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) int usersId,
+    @JsonKey(fromJson: _intFromJson) int foldersId,
     String attachmentsType,
     String objectKey,
     String presignedUrl,
@@ -1910,9 +1943,9 @@ class __$$SearchFileItemDtoImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$SearchFileItemDtoImpl implements _SearchFileItemDto {
   const _$SearchFileItemDtoImpl({
-    required this.attachmentsId,
-    required this.usersId,
-    required this.foldersId,
+    @JsonKey(fromJson: _intFromJson) this.attachmentsId = 0,
+    @JsonKey(fromJson: _intFromJson) this.usersId = 0,
+    @JsonKey(fromJson: _intFromJson) this.foldersId = 0,
     this.attachmentsType = '',
     this.objectKey = '',
     this.presignedUrl = '',
@@ -1926,10 +1959,13 @@ class _$SearchFileItemDtoImpl implements _SearchFileItemDto {
       _$$SearchFileItemDtoImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int attachmentsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int foldersId;
   @override
   @JsonKey()
@@ -2018,9 +2054,9 @@ class _$SearchFileItemDtoImpl implements _SearchFileItemDto {
 
 abstract class _SearchFileItemDto implements SearchFileItemDto {
   const factory _SearchFileItemDto({
-    required final int attachmentsId,
-    required final int usersId,
-    required final int foldersId,
+    @JsonKey(fromJson: _intFromJson) final int attachmentsId,
+    @JsonKey(fromJson: _intFromJson) final int usersId,
+    @JsonKey(fromJson: _intFromJson) final int foldersId,
     final String attachmentsType,
     final String objectKey,
     final String presignedUrl,
@@ -2034,10 +2070,13 @@ abstract class _SearchFileItemDto implements SearchFileItemDto {
       _$SearchFileItemDtoImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get attachmentsId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get usersId;
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get foldersId;
   @override
   String get attachmentsType;

--- a/lib/models/dto/search_response_dto.g.dart
+++ b/lib/models/dto/search_response_dto.g.dart
@@ -51,8 +51,8 @@ Map<String, dynamic> _$$SearchResponseDtoImplToJson(
 _$SearchFolderItemDtoImpl _$$SearchFolderItemDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$SearchFolderItemDtoImpl(
-  foldersId: (json['foldersId'] as num).toInt(),
-  usersId: (json['usersId'] as num).toInt(),
+  foldersId: json['foldersId'] == null ? 0 : _intFromJson(json['foldersId']),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
   name: json['name'] as String? ?? '',
   memo: json['memo'] as String? ?? '',
   isDefault: json['isDefault'] == null
@@ -83,8 +83,10 @@ Map<String, dynamic> _$$SearchFolderItemDtoImplToJson(
 _$SearchScheduleItemDtoImpl _$$SearchScheduleItemDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$SearchScheduleItemDtoImpl(
-  usersId: (json['usersId'] as num).toInt(),
-  schedulesId: (json['schedulesId'] as num).toInt(),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
+  schedulesId: json['schedulesId'] == null
+      ? 0
+      : _intFromJson(json['schedulesId']),
   title: json['title'] as String? ?? '',
   foldersId: (json['foldersId'] as num?)?.toInt() ?? 0,
   foldersTitle: json['foldersTitle'] as String? ?? '',
@@ -119,9 +121,9 @@ Map<String, dynamic> _$$SearchScheduleItemDtoImplToJson(
 _$SearchLinkItemDtoImpl _$$SearchLinkItemDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$SearchLinkItemDtoImpl(
-  linksId: (json['linksId'] as num).toInt(),
-  foldersId: (json['foldersId'] as num).toInt(),
-  usersId: (json['usersId'] as num).toInt(),
+  linksId: json['linksId'] == null ? 0 : _intFromJson(json['linksId']),
+  foldersId: json['foldersId'] == null ? 0 : _intFromJson(json['foldersId']),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
   linksName: json['linksName'] as String? ?? '',
   linksUrl: json['linksUrl'] as String? ?? '',
   linksThumbnail: json['linksThumbnail'] as String? ?? '',
@@ -145,9 +147,9 @@ Map<String, dynamic> _$$SearchLinkItemDtoImplToJson(
 _$SearchTextItemDtoImpl _$$SearchTextItemDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$SearchTextItemDtoImpl(
-  textsId: (json['textsId'] as num).toInt(),
-  usersId: (json['usersId'] as num).toInt(),
-  foldersId: (json['foldersId'] as num).toInt(),
+  textsId: json['textsId'] == null ? 0 : _intFromJson(json['textsId']),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
+  foldersId: json['foldersId'] == null ? 0 : _intFromJson(json['foldersId']),
   textContent: json['textContent'] as String? ?? '',
   createdAt: json['createdAt'] as String?,
 );
@@ -165,9 +167,11 @@ Map<String, dynamic> _$$SearchTextItemDtoImplToJson(
 _$SearchFileItemDtoImpl _$$SearchFileItemDtoImplFromJson(
   Map<String, dynamic> json,
 ) => _$SearchFileItemDtoImpl(
-  attachmentsId: (json['attachmentsId'] as num).toInt(),
-  usersId: (json['usersId'] as num).toInt(),
-  foldersId: (json['foldersId'] as num).toInt(),
+  attachmentsId: json['attachmentsId'] == null
+      ? 0
+      : _intFromJson(json['attachmentsId']),
+  usersId: json['usersId'] == null ? 0 : _intFromJson(json['usersId']),
+  foldersId: json['foldersId'] == null ? 0 : _intFromJson(json['foldersId']),
   attachmentsType: json['attachmentsType'] as String? ?? '',
   objectKey: json['objectKey'] as String? ?? '',
   presignedUrl: json['presignedUrl'] as String? ?? '',

--- a/lib/models/schedule/schedule_response.dart
+++ b/lib/models/schedule/schedule_response.dart
@@ -21,8 +21,8 @@ String _stringFromJson(dynamic value) {
 @freezed
 class ScheduleSearchResponse with _$ScheduleSearchResponse {
   const factory ScheduleSearchResponse({
-    required int userId,
-    required List<ScheduleItemResponse> schedulesResponses,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int userId,
+    @Default([]) List<ScheduleItemResponse> schedulesResponses,
   }) = _ScheduleSearchResponse;
 
   factory ScheduleSearchResponse.fromJson(Map<String, dynamic> json) =>
@@ -48,8 +48,8 @@ class ScheduleItemResponse with _$ScheduleItemResponse {
 @freezed
 class SelectedSchedulesResponse with _$SelectedSchedulesResponse {
   const factory SelectedSchedulesResponse({
-    required int userId,
-    required List<SelectedScheduleItemResponse> schedulesResponses,
+    @JsonKey(fromJson: _intFromJson) @Default(0) int userId,
+    @Default([]) List<SelectedScheduleItemResponse> schedulesResponses,
   }) = _SelectedSchedulesResponse;
 
   factory SelectedSchedulesResponse.fromJson(Map<String, dynamic> json) =>
@@ -75,7 +75,7 @@ class SelectedScheduleItemResponse with _$SelectedScheduleItemResponse {
 @freezed
 class ScheduleDetailResponse with _$ScheduleDetailResponse {
   const factory ScheduleDetailResponse({
-    @JsonKey(fromJson: _intFromJson) required int userId,
+    @Default(0) int userId,
     @JsonKey(fromJson: _intFromJson) required int schedulesId,
     @JsonKey(fromJson: _stringFromJson) required String title,
     @JsonKey(fromJson: _intFromJson) @Default(0) int foldersId,

--- a/lib/models/schedule/schedule_response.freezed.dart
+++ b/lib/models/schedule/schedule_response.freezed.dart
@@ -23,6 +23,7 @@ ScheduleSearchResponse _$ScheduleSearchResponseFromJson(
 
 /// @nodoc
 mixin _$ScheduleSearchResponse {
+  @JsonKey(fromJson: _intFromJson)
   int get userId => throw _privateConstructorUsedError;
   List<ScheduleItemResponse> get schedulesResponses =>
       throw _privateConstructorUsedError;
@@ -44,7 +45,10 @@ abstract class $ScheduleSearchResponseCopyWith<$Res> {
     $Res Function(ScheduleSearchResponse) then,
   ) = _$ScheduleSearchResponseCopyWithImpl<$Res, ScheduleSearchResponse>;
   @useResult
-  $Res call({int userId, List<ScheduleItemResponse> schedulesResponses});
+  $Res call({
+    @JsonKey(fromJson: _intFromJson) int userId,
+    List<ScheduleItemResponse> schedulesResponses,
+  });
 }
 
 /// @nodoc
@@ -90,7 +94,10 @@ abstract class _$$ScheduleSearchResponseImplCopyWith<$Res>
   ) = __$$ScheduleSearchResponseImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({int userId, List<ScheduleItemResponse> schedulesResponses});
+  $Res call({
+    @JsonKey(fromJson: _intFromJson) int userId,
+    List<ScheduleItemResponse> schedulesResponses,
+  });
 }
 
 /// @nodoc
@@ -127,17 +134,19 @@ class __$$ScheduleSearchResponseImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$ScheduleSearchResponseImpl implements _ScheduleSearchResponse {
   const _$ScheduleSearchResponseImpl({
-    required this.userId,
-    required final List<ScheduleItemResponse> schedulesResponses,
+    @JsonKey(fromJson: _intFromJson) this.userId = 0,
+    final List<ScheduleItemResponse> schedulesResponses = const [],
   }) : _schedulesResponses = schedulesResponses;
 
   factory _$ScheduleSearchResponseImpl.fromJson(Map<String, dynamic> json) =>
       _$$ScheduleSearchResponseImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int userId;
   final List<ScheduleItemResponse> _schedulesResponses;
   @override
+  @JsonKey()
   List<ScheduleItemResponse> get schedulesResponses {
     if (_schedulesResponses is EqualUnmodifiableListView)
       return _schedulesResponses;
@@ -190,14 +199,15 @@ class _$ScheduleSearchResponseImpl implements _ScheduleSearchResponse {
 
 abstract class _ScheduleSearchResponse implements ScheduleSearchResponse {
   const factory _ScheduleSearchResponse({
-    required final int userId,
-    required final List<ScheduleItemResponse> schedulesResponses,
+    @JsonKey(fromJson: _intFromJson) final int userId,
+    final List<ScheduleItemResponse> schedulesResponses,
   }) = _$ScheduleSearchResponseImpl;
 
   factory _ScheduleSearchResponse.fromJson(Map<String, dynamic> json) =
       _$ScheduleSearchResponseImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get userId;
   @override
   List<ScheduleItemResponse> get schedulesResponses;
@@ -490,6 +500,7 @@ SelectedSchedulesResponse _$SelectedSchedulesResponseFromJson(
 
 /// @nodoc
 mixin _$SelectedSchedulesResponse {
+  @JsonKey(fromJson: _intFromJson)
   int get userId => throw _privateConstructorUsedError;
   List<SelectedScheduleItemResponse> get schedulesResponses =>
       throw _privateConstructorUsedError;
@@ -512,7 +523,7 @@ abstract class $SelectedSchedulesResponseCopyWith<$Res> {
   ) = _$SelectedSchedulesResponseCopyWithImpl<$Res, SelectedSchedulesResponse>;
   @useResult
   $Res call({
-    int userId,
+    @JsonKey(fromJson: _intFromJson) int userId,
     List<SelectedScheduleItemResponse> schedulesResponses,
   });
 }
@@ -561,7 +572,7 @@ abstract class _$$SelectedSchedulesResponseImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    int userId,
+    @JsonKey(fromJson: _intFromJson) int userId,
     List<SelectedScheduleItemResponse> schedulesResponses,
   });
 }
@@ -603,17 +614,19 @@ class __$$SelectedSchedulesResponseImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$SelectedSchedulesResponseImpl implements _SelectedSchedulesResponse {
   const _$SelectedSchedulesResponseImpl({
-    required this.userId,
-    required final List<SelectedScheduleItemResponse> schedulesResponses,
+    @JsonKey(fromJson: _intFromJson) this.userId = 0,
+    final List<SelectedScheduleItemResponse> schedulesResponses = const [],
   }) : _schedulesResponses = schedulesResponses;
 
   factory _$SelectedSchedulesResponseImpl.fromJson(Map<String, dynamic> json) =>
       _$$SelectedSchedulesResponseImplFromJson(json);
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   final int userId;
   final List<SelectedScheduleItemResponse> _schedulesResponses;
   @override
+  @JsonKey()
   List<SelectedScheduleItemResponse> get schedulesResponses {
     if (_schedulesResponses is EqualUnmodifiableListView)
       return _schedulesResponses;
@@ -665,14 +678,15 @@ class _$SelectedSchedulesResponseImpl implements _SelectedSchedulesResponse {
 
 abstract class _SelectedSchedulesResponse implements SelectedSchedulesResponse {
   const factory _SelectedSchedulesResponse({
-    required final int userId,
-    required final List<SelectedScheduleItemResponse> schedulesResponses,
+    @JsonKey(fromJson: _intFromJson) final int userId,
+    final List<SelectedScheduleItemResponse> schedulesResponses,
   }) = _$SelectedSchedulesResponseImpl;
 
   factory _SelectedSchedulesResponse.fromJson(Map<String, dynamic> json) =
       _$SelectedSchedulesResponseImpl.fromJson;
 
   @override
+  @JsonKey(fromJson: _intFromJson)
   int get userId;
   @override
   List<SelectedScheduleItemResponse> get schedulesResponses;
@@ -975,7 +989,6 @@ ScheduleDetailResponse _$ScheduleDetailResponseFromJson(
 
 /// @nodoc
 mixin _$ScheduleDetailResponse {
-  @JsonKey(fromJson: _intFromJson)
   int get userId => throw _privateConstructorUsedError;
   @JsonKey(fromJson: _intFromJson)
   int get schedulesId => throw _privateConstructorUsedError;
@@ -1015,7 +1028,7 @@ abstract class $ScheduleDetailResponseCopyWith<$Res> {
   ) = _$ScheduleDetailResponseCopyWithImpl<$Res, ScheduleDetailResponse>;
   @useResult
   $Res call({
-    @JsonKey(fromJson: _intFromJson) int userId,
+    int userId,
     @JsonKey(fromJson: _intFromJson) int schedulesId,
     @JsonKey(fromJson: _stringFromJson) String title,
     @JsonKey(fromJson: _intFromJson) int foldersId,
@@ -1133,7 +1146,7 @@ abstract class _$$ScheduleDetailResponseImplCopyWith<$Res>
   @override
   @useResult
   $Res call({
-    @JsonKey(fromJson: _intFromJson) int userId,
+    int userId,
     @JsonKey(fromJson: _intFromJson) int schedulesId,
     @JsonKey(fromJson: _stringFromJson) String title,
     @JsonKey(fromJson: _intFromJson) int foldersId,
@@ -1241,7 +1254,7 @@ class __$$ScheduleDetailResponseImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$ScheduleDetailResponseImpl implements _ScheduleDetailResponse {
   const _$ScheduleDetailResponseImpl({
-    @JsonKey(fromJson: _intFromJson) required this.userId,
+    this.userId = 0,
     @JsonKey(fromJson: _intFromJson) required this.schedulesId,
     @JsonKey(fromJson: _stringFromJson) required this.title,
     @JsonKey(fromJson: _intFromJson) this.foldersId = 0,
@@ -1260,7 +1273,7 @@ class _$ScheduleDetailResponseImpl implements _ScheduleDetailResponse {
       _$$ScheduleDetailResponseImplFromJson(json);
 
   @override
-  @JsonKey(fromJson: _intFromJson)
+  @JsonKey()
   final int userId;
   @override
   @JsonKey(fromJson: _intFromJson)
@@ -1369,7 +1382,7 @@ class _$ScheduleDetailResponseImpl implements _ScheduleDetailResponse {
 
 abstract class _ScheduleDetailResponse implements ScheduleDetailResponse {
   const factory _ScheduleDetailResponse({
-    @JsonKey(fromJson: _intFromJson) required final int userId,
+    final int userId,
     @JsonKey(fromJson: _intFromJson) required final int schedulesId,
     @JsonKey(fromJson: _stringFromJson) required final String title,
     @JsonKey(fromJson: _intFromJson) final int foldersId,
@@ -1388,7 +1401,6 @@ abstract class _ScheduleDetailResponse implements ScheduleDetailResponse {
       _$ScheduleDetailResponseImpl.fromJson;
 
   @override
-  @JsonKey(fromJson: _intFromJson)
   int get userId;
   @override
   @JsonKey(fromJson: _intFromJson)

--- a/lib/models/schedule/schedule_response.g.dart
+++ b/lib/models/schedule/schedule_response.g.dart
@@ -9,10 +9,12 @@ part of 'schedule_response.dart';
 _$ScheduleSearchResponseImpl _$$ScheduleSearchResponseImplFromJson(
   Map<String, dynamic> json,
 ) => _$ScheduleSearchResponseImpl(
-  userId: (json['userId'] as num).toInt(),
-  schedulesResponses: (json['schedulesResponses'] as List<dynamic>)
-      .map((e) => ScheduleItemResponse.fromJson(e as Map<String, dynamic>))
-      .toList(),
+  userId: json['userId'] == null ? 0 : _intFromJson(json['userId']),
+  schedulesResponses:
+      (json['schedulesResponses'] as List<dynamic>?)
+          ?.map((e) => ScheduleItemResponse.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
 );
 
 Map<String, dynamic> _$$ScheduleSearchResponseImplToJson(
@@ -45,12 +47,16 @@ Map<String, dynamic> _$$ScheduleItemResponseImplToJson(
 _$SelectedSchedulesResponseImpl _$$SelectedSchedulesResponseImplFromJson(
   Map<String, dynamic> json,
 ) => _$SelectedSchedulesResponseImpl(
-  userId: (json['userId'] as num).toInt(),
-  schedulesResponses: (json['schedulesResponses'] as List<dynamic>)
-      .map(
-        (e) => SelectedScheduleItemResponse.fromJson(e as Map<String, dynamic>),
-      )
-      .toList(),
+  userId: json['userId'] == null ? 0 : _intFromJson(json['userId']),
+  schedulesResponses:
+      (json['schedulesResponses'] as List<dynamic>?)
+          ?.map(
+            (e) => SelectedScheduleItemResponse.fromJson(
+              e as Map<String, dynamic>,
+            ),
+          )
+          .toList() ??
+      const [],
 );
 
 Map<String, dynamic> _$$SelectedSchedulesResponseImplToJson(
@@ -83,7 +89,7 @@ Map<String, dynamic> _$$SelectedScheduleItemResponseImplToJson(
 _$ScheduleDetailResponseImpl _$$ScheduleDetailResponseImplFromJson(
   Map<String, dynamic> json,
 ) => _$ScheduleDetailResponseImpl(
-  userId: _intFromJson(json['userId']),
+  userId: (json['userId'] as num?)?.toInt() ?? 0,
   schedulesId: _intFromJson(json['schedulesId']),
   title: _stringFromJson(json['title']),
   foldersId: json['foldersId'] == null ? 0 : _intFromJson(json['foldersId']),


### PR DESCRIPTION
refactor: userId 미포함 응답 대응 DTO 파싱 안정화

- 홈/검색/보관함/일정 DTO에서 userId/usersId 필드를 기본값 파싱 구조로 정리
- null, 문자열, 숫자 타입 혼합 응답에도 안전하게 int 변환되도록 fromJson 처리 보완
- DTO 변경사항을 반영해 freezed/json_serializable 생성 파일 재생성