### PR TITLE
feat: iOS Share Extension 및 Android 외부 이미지 공유 수신 기능 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,16 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
         </activity>
         <!-- 딥링크 -->
         <activity

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -31,6 +31,9 @@ target 'Runner' do
   use_frameworks!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'Share Extension' do
+    inherit! :search_paths
+  end
   target 'RunnerTests' do
     inherit! :search_paths
   end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -106,6 +106,8 @@ PODS:
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
   - PromisesObjC (2.4.0)
+  - receive_sharing_intent (1.8.1):
+    - Flutter
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
@@ -124,6 +126,7 @@ DEPENDENCIES:
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - receive_sharing_intent (from `.symlinks/plugins/receive_sharing_intent/ios`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -158,6 +161,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_web_auth_2/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  receive_sharing_intent:
+    :path: ".symlinks/plugins/receive_sharing_intent/ios"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
   url_launcher_ios:
@@ -166,27 +171,28 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
+  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
-  firebase_core: 8d5e24676350f15dd111aa59a88a1ae26605f9ba
-  firebase_messaging: 834cfc0887393d3108cdb19da8e57655c54fd0e4
+  firebase_core: ee30637e6744af8e0c12a6a1e8a9718506ec2398
+  firebase_messaging: 343de01a8d3e18b60df0c6d37f7174c44ae38e02
   FirebaseCore: 0dbad74bda10b8fb9ca34ad8f375fb9dd3ebef7c
   FirebaseCoreInternal: fe5fa466aeb314787093a7dce9f0beeaad5a2a21
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseMessaging: 7f42cfd10ec64181db4e01b305a613791c8e782c
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
-  flutter_web_auth_2: 4091f1645696258ddc57849f62bef2a848fc313c
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
-PODFILE CHECKSUM: 71049cc3bde67d97d13cf5f7c792ca68cbd51b1c
+PODFILE CHECKSUM: 9e96353205564ae51eaf5422c660a3c602958b89
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		C3E333127AFD7023C03D2E45 /* Pods_Share_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB4A9AC174B0F65B88F0D42F /* Pods_Share_Extension.framework */; };
+		D0A8C8AC5EE65B216FC1DCD6 /* TokenBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E27EA748E9EC5EEC16A811A /* TokenBridge.swift */; };
+		DB4BC0492F8F7EE200918EF1 /* Share Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DB4BC03F2F8F7EE200918EF1 /* Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E1E8E9F2E8E5187684C15757 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2523613EF1D0B97C206D6B07 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
@@ -27,6 +30,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
 			remoteInfo = Runner;
+		};
+		DB4BC0472F8F7EE200918EF1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DB4BC03E2F8F7EE200918EF1;
+			remoteInfo = "Share Extension";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -41,9 +51,22 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DB4BC04A2F8F7EE200918EF1 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				DB4BC0492F8F7EE200918EF1 /* Share Extension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0D39D771E161E52EFD28D301 /* Pods-Share Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.debug.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		0F79A1145EFA912E92AEC43D /* Pods-Share Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.release.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.release.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		2523613EF1D0B97C206D6B07 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -52,6 +75,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		4B9982A425729D4776FADF64 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		5A068DDA7BB8330903513CCD /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		60972EAEE81C473C52DFA452 /* Pods-Share Extension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.profile.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.profile.xcconfig"; sourceTree = "<group>"; };
 		6BE4F807384AC36B13392915 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -65,11 +89,39 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9E27EA748E9EC5EEC16A811A /* TokenBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenBridge.swift; sourceTree = "<group>"; };
 		AAF0B8C4E6873A793D23EF06 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB44BB73A6861DEE0DA8F427 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		AF285735E22CA716385D5F67 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		CB4A9AC174B0F65B88F0D42F /* Pods_Share_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Share_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA3DB9D1828A4FA2D9CF8D1F /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		DB4BC03F2F8F7EE200918EF1 /* Share Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Share Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		DB4BC04E2F8F7EE200918EF1 /* Exceptions for "Share Extension" folder in "Share Extension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = DB4BC03E2F8F7EE200918EF1 /* Share Extension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		DB4BC0402F8F7EE200918EF1 /* Share Extension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				DB4BC04E2F8F7EE200918EF1 /* Exceptions for "Share Extension" folder in "Share Extension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Share Extension";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		298D38F36620E7809D209A11 /* Frameworks */ = {
@@ -88,6 +140,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DB4BC03C2F8F7EE200918EF1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C3E333127AFD7023C03D2E45 /* Pods_Share_Extension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -100,8 +160,10 @@
 				6BE4F807384AC36B13392915 /* Pods-RunnerTests.debug.xcconfig */,
 				AB44BB73A6861DEE0DA8F427 /* Pods-RunnerTests.release.xcconfig */,
 				AF285735E22CA716385D5F67 /* Pods-RunnerTests.profile.xcconfig */,
+				0D39D771E161E52EFD28D301 /* Pods-Share Extension.debug.xcconfig */,
+				0F79A1145EFA912E92AEC43D /* Pods-Share Extension.release.xcconfig */,
+				60972EAEE81C473C52DFA452 /* Pods-Share Extension.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -129,6 +191,7 @@
 			children = (
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
+				DB4BC0402F8F7EE200918EF1 /* Share Extension */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				1EA23120530829B2A92F0E9E /* Pods */,
@@ -142,6 +205,7 @@
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
 				331C8081294A63A400263BE5 /* RunnerTests.xctest */,
+				DB4BC03F2F8F7EE200918EF1 /* Share Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -158,6 +222,7 @@
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				9E27EA748E9EC5EEC16A811A /* TokenBridge.swift */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -167,6 +232,7 @@
 			children = (
 				7D55FAFDD32490B89E37ED5F /* Pods_Runner.framework */,
 				AAF0B8C4E6873A793D23EF06 /* Pods_RunnerTests.framework */,
+				CB4A9AC174B0F65B88F0D42F /* Pods_Share_Extension.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -203,6 +269,7 @@
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
+				DB4BC04A2F8F7EE200918EF1 /* Embed Foundation Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				E0491D00C5A9CCAC898E4866 /* [CP] Embed Pods Frameworks */,
 				6450D9E2872B215C36B11628 /* [CP] Copy Pods Resources */,
@@ -210,11 +277,33 @@
 			buildRules = (
 			);
 			dependencies = (
+				DB4BC0482F8F7EE200918EF1 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
+		};
+		DB4BC03E2F8F7EE200918EF1 /* Share Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DB4BC04F2F8F7EE200918EF1 /* Build configuration list for PBXNativeTarget "Share Extension" */;
+			buildPhases = (
+				55BDC0E076825544388409B4 /* [CP] Check Pods Manifest.lock */,
+				DB4BC03B2F8F7EE200918EF1 /* Sources */,
+				DB4BC03C2F8F7EE200918EF1 /* Frameworks */,
+				DB4BC03D2F8F7EE200918EF1 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				DB4BC0402F8F7EE200918EF1 /* Share Extension */,
+			);
+			name = "Share Extension";
+			productName = "Share Extension";
+			productReference = DB4BC03F2F8F7EE200918EF1 /* Share Extension.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -223,6 +312,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
+				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
@@ -233,6 +323,9 @@
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 1100;
+					};
+					DB4BC03E2F8F7EE200918EF1 = {
+						CreatedOnToolsVersion = 26.2;
 					};
 				};
 			};
@@ -251,6 +344,7 @@
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
 				331C8080294A63A400263BE5 /* RunnerTests */,
+				DB4BC03E2F8F7EE200918EF1 /* Share Extension */,
 			);
 		};
 /* End PBXProject section */
@@ -272,6 +366,13 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				E1E8E9F2E8E5187684C15757 /* GoogleService-Info.plist in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB4BC03D2F8F7EE200918EF1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -315,6 +416,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		55BDC0E076825544388409B4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Share Extension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		6450D9E2872B215C36B11628 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -370,23 +493,6 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
 		};
-		CE304618AEB9F48BF50E75BC /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		E0491D00C5A9CCAC898E4866 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -422,6 +528,14 @@
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
+				D0A8C8AC5EE65B216FC1DCD6 /* TokenBridge.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DB4BC03B2F8F7EE200918EF1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -432,6 +546,11 @@
 			isa = PBXTargetDependency;
 			target = 97C146ED1CF9000F007C117D /* Runner */;
 			targetProxy = 331C8085294A63A400263BE5 /* PBXContainerItemProxy */;
+		};
+		DB4BC0482F8F7EE200918EF1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DB4BC03E2F8F7EE200918EF1 /* Share Extension */;
+			targetProxy = DB4BC0472F8F7EE200918EF1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -513,7 +632,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.com.example.pojTodo.share;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -695,8 +816,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.com.example.pojTodo.share;
 				DEVELOPMENT_TEAM = M6AFC979G8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -719,8 +842,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				CUSTOM_GROUP_ID = group.com.example.pojTodo.share;
 				DEVELOPMENT_TEAM = M6AFC979G8;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -735,6 +860,134 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;
+		};
+		DB4BC04B2F8F7EE200918EF1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D39D771E161E52EFD28D301 /* Pods-Share Extension.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				CUSTOM_GROUP_ID = group.com.example.pojTodo.share;
+				DEVELOPMENT_TEAM = M6AFC979G8;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Share Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Share Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.pojTodo.Share-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DB4BC04C2F8F7EE200918EF1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0F79A1145EFA912E92AEC43D /* Pods-Share Extension.release.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				CUSTOM_GROUP_ID = group.com.example.pojTodo.share;
+				DEVELOPMENT_TEAM = M6AFC979G8;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Share Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Share Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.pojTodo.Share-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		DB4BC04D2F8F7EE200918EF1 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 60972EAEE81C473C52DFA452 /* Pods-Share Extension.profile.xcconfig */;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				CUSTOM_GROUP_ID = group.com.example.pojTodo.share;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "Share Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Share Extension";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.pojTodo.Share-Extension";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Profile;
 		};
 /* End XCBuildConfiguration section */
 
@@ -765,6 +1018,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DB4BC04F2F8F7EE200918EF1 /* Build configuration list for PBXNativeTarget "Share Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DB4BC04B2F8F7EE200918EF1 /* Debug */,
+				DB4BC04C2F8F7EE200918EF1 /* Release */,
+				DB4BC04D2F8F7EE200918EF1 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,10 +8,13 @@ import FirebaseMessaging
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    // 푸시 알림 권한 설정
     UNUserNotificationCenter.current().delegate = self
     application.registerForRemoteNotifications()
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+
+    return super.application(
+      application,
+      didFinishLaunchingWithOptions: launchOptions
+    )
   }
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -67,6 +67,8 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<!-- 딥링크 -->
+	<key>AppGroupId</key>
+	<string>$(CUSTOM_GROUP_ID)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -75,6 +77,14 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>toit</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ShareMedia-$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.example.pojTodo.share</string>
+	</array>
+</dict>
+</plist>

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -3,4 +3,41 @@ import UIKit
 
 class SceneDelegate: FlutterSceneDelegate {
 
+  override func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    super.scene(scene, willConnectTo: session, options: connectionOptions)
+    registerTokenBridge()
+  }
+
+  override func scene(
+    _ scene: UIScene,
+    openURLContexts URLContexts: Set<UIOpenURLContext>
+  ) {
+    guard let url = URLContexts.first?.url else { return }
+    handleDeepLink(url)
+  }
+
+  private func registerTokenBridge() {
+    guard let window = self.window,
+          let controller = window.rootViewController
+            as? FlutterViewController
+    else { return }
+    TokenBridge.register(with: controller.binaryMessenger)
+  }
+
+  private func handleDeepLink(_ url: URL) {
+    guard let window = self.window,
+          let controller = window.rootViewController
+            as? FlutterViewController
+    else { return }
+
+    let channel = FlutterMethodChannel(
+      name: "com.example.pojTodo/deeplink",
+      binaryMessenger: controller.binaryMessenger
+    )
+    channel.invokeMethod("onDeepLink", arguments: url.absoluteString)
+  }
 }

--- a/ios/Runner/TokenBridge.swift
+++ b/ios/Runner/TokenBridge.swift
@@ -1,0 +1,81 @@
+import Flutter
+import Foundation
+
+/// Flutter MethodChannel을 통해 토큰·설정 값을
+/// App Group UserDefaults에 저장하여 Share Extension과 공유한다.
+final class TokenBridge {
+  static let channelName = "com.example.pojTodo/token"
+
+  private static let suiteName = "group.com.example.pojTodo.share"
+  static let keyAccessToken = "access_token"
+  static let keyUserId = "user_id"
+  static let keyBaseUrl = "api_base_url"
+
+  static func register(with messenger: FlutterBinaryMessenger) {
+    let channel = FlutterMethodChannel(
+      name: channelName,
+      binaryMessenger: messenger
+    )
+
+    channel.setMethodCallHandler { call, result in
+      switch call.method {
+      case "syncToken":
+        guard let args = call.arguments as? [String: Any],
+              let accessToken = args["accessToken"] as? String,
+              let userId = args["userId"] as? Int,
+              let baseUrl = args["baseUrl"] as? String
+        else {
+          result(
+            FlutterError(
+              code: "INVALID_ARGS",
+              message: "accessToken, userId, baseUrl 필수",
+              details: nil
+            )
+          )
+          return
+        }
+        save(
+          accessToken: accessToken,
+          userId: userId,
+          baseUrl: baseUrl
+        )
+        result(true)
+
+      case "clearToken":
+        clear()
+        result(true)
+
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private static func save(
+    accessToken: String,
+    userId: Int,
+    baseUrl: String
+  ) {
+    guard let defaults = UserDefaults(suiteName: suiteName)
+    else {
+      NSLog("[TokenBridge] UserDefaults 생성 실패 - suiteName: \(suiteName)")
+      return
+    }
+    defaults.set(accessToken, forKey: keyAccessToken)
+    defaults.set(userId, forKey: keyUserId)
+    defaults.set(baseUrl, forKey: keyBaseUrl)
+    defaults.synchronize()
+
+    let verify = defaults.string(forKey: keyAccessToken)
+    NSLog("[TokenBridge] 저장 완료 - token: \(verify != nil ? "있음" : "nil"), userId: \(userId), baseUrl: \(baseUrl)")
+  }
+
+  private static func clear() {
+    guard let defaults = UserDefaults(suiteName: suiteName)
+    else { return }
+    defaults.removeObject(forKey: keyAccessToken)
+    defaults.removeObject(forKey: keyUserId)
+    defaults.removeObject(forKey: keyBaseUrl)
+    defaults.synchronize()
+  }
+}

--- a/ios/Share Extension/Base.lproj/MainInterface.storyboard
+++ b/ios/Share Extension/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ios/Share Extension/Info.plist
+++ b/ios/Share Extension/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppGroupId</key>
+	<string>$(CUSTOM_GROUP_ID)</string>
+	<key>CFBundleVersion</key>
+	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>PHSupportedMediaTypes</key>
+			<array>
+				<string>Image</string>
+			</array>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+				<integer>30</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/Share Extension/Share Extension.entitlements
+++ b/ios/Share Extension/Share Extension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(CUSTOM_GROUP_ID)</string>
+	</array>
+</dict>
+</plist>

--- a/ios/Share Extension/ShareApiClient.swift
+++ b/ios/Share Extension/ShareApiClient.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// Share Extension 전용 경량 API 클라이언트.
+/// App Group UserDefaults에서 인증 정보를 읽어 URLSession으로 호출한다.
+final class ShareApiClient {
+  private let accessToken: String
+  private let baseUrl: String
+  let userId: Int
+
+  private static let suiteName =
+    "group.com.example.pojTodo.share"
+
+  init?(fromAppGroup: Void = ()) {
+    guard let defaults = UserDefaults(
+      suiteName: ShareApiClient.suiteName
+    ) else {
+      NSLog("[ShareApiClient] UserDefaults 생성 실패 - suiteName: \(ShareApiClient.suiteName)")
+      return nil
+    }
+
+    let token = defaults.string(forKey: "access_token")
+    let url = defaults.string(forKey: "api_base_url")
+    let uid = defaults.integer(forKey: "user_id")
+
+    NSLog("[ShareApiClient] App Group 읽기 결과 - token: \(token != nil ? "있음(\(token!.prefix(10))...)" : "nil"), url: \(url ?? "nil"), userId: \(uid)")
+
+    guard let token, let url,
+          !token.isEmpty, !url.isEmpty
+    else { return nil }
+
+    self.accessToken = token
+    self.baseUrl = url
+    self.userId = uid
+  }
+
+  // MARK: - Folder List
+
+  func fetchFolders() async throws -> [ShareFolder] {
+    let today = Self.todayString()
+    var components = URLComponents(
+      string: "\(baseUrl)/page/home"
+    )!
+    components.queryItems = [
+      URLQueryItem(name: "usersId", value: "\(userId)"),
+      URLQueryItem(name: "todayDate", value: today),
+    ]
+
+    let (data, response) = try await request(
+      url: components.url!,
+      method: "GET"
+    )
+    try validateResponse(response)
+
+    guard let json = try JSONSerialization.jsonObject(
+      with: data
+    ) as? [String: Any],
+      let foldersJson = json["folders"] as? [[String: Any]]
+    else { return [] }
+
+    return foldersJson.compactMap { ShareFolder(json: $0) }
+  }
+
+  // MARK: - Upload Image
+
+  func uploadImage(
+    data imageData: Data,
+    fileName: String,
+    folderId: Int,
+    textContent: String
+  ) async throws {
+    var components = URLComponents(
+      string: "\(baseUrl)/attachments/images"
+    )!
+    components.queryItems = [
+      URLQueryItem(name: "usersId", value: "\(userId)"),
+      URLQueryItem(
+        name: "foldersIdList", value: "\(folderId)"
+      ),
+      URLQueryItem(name: "textContent", value: textContent),
+    ]
+
+    try await uploadMultipart(
+      url: components.url!,
+      fieldName: "image",
+      fileData: imageData,
+      fileName: fileName,
+      mimeType: "image/jpeg"
+    )
+  }
+
+  // MARK: - Upload File
+
+  func uploadFile(
+    data fileData: Data,
+    fileName: String,
+    folderId: Int,
+    textContent: String
+  ) async throws {
+    var components = URLComponents(
+      string: "\(baseUrl)/attachments/files"
+    )!
+    components.queryItems = [
+      URLQueryItem(name: "usersId", value: "\(userId)"),
+      URLQueryItem(
+        name: "foldersIdList", value: "\(folderId)"
+      ),
+      URLQueryItem(name: "textContent", value: textContent),
+    ]
+
+    try await uploadMultipart(
+      url: components.url!,
+      fieldName: "file",
+      fileData: fileData,
+      fileName: fileName,
+      mimeType: "application/octet-stream"
+    )
+  }
+
+  // MARK: - Private Helpers
+
+  private func request(
+    url: URL,
+    method: String
+  ) async throws -> (Data, URLResponse) {
+    var req = URLRequest(url: url)
+    req.httpMethod = method
+    req.setValue(
+      "Bearer \(accessToken)",
+      forHTTPHeaderField: "Authorization"
+    )
+    req.timeoutInterval = 15
+    return try await URLSession.shared.data(for: req)
+  }
+
+  private func uploadMultipart(
+    url: URL,
+    fieldName: String,
+    fileData: Data,
+    fileName: String,
+    mimeType: String
+  ) async throws {
+    let boundary = UUID().uuidString
+
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    req.setValue(
+      "Bearer \(accessToken)",
+      forHTTPHeaderField: "Authorization"
+    )
+    req.setValue(
+      "multipart/form-data; boundary=\(boundary)",
+      forHTTPHeaderField: "Content-Type"
+    )
+    req.timeoutInterval = 60
+
+    var body = Data()
+    let crlf = "\r\n"
+    body.append(
+      "--\(boundary)\(crlf)"
+        .data(using: .utf8)!
+    )
+    body.append(
+      ("Content-Disposition: form-data; " +
+        "name=\"\(fieldName)\"; " +
+        "filename=\"\(fileName)\"\(crlf)")
+        .data(using: .utf8)!
+    )
+    body.append(
+      "Content-Type: \(mimeType)\(crlf)\(crlf)"
+        .data(using: .utf8)!
+    )
+    body.append(fileData)
+    body.append(
+      "\(crlf)--\(boundary)--\(crlf)"
+        .data(using: .utf8)!
+    )
+    req.httpBody = body
+
+    let (_, response) = try await URLSession.shared.data(
+      for: req
+    )
+    try validateResponse(response)
+  }
+
+  private func validateResponse(
+    _ response: URLResponse
+  ) throws {
+    guard let http = response as? HTTPURLResponse else {
+      throw ShareApiError.invalidResponse
+    }
+    switch http.statusCode {
+    case 200...299:
+      return
+    case 401:
+      throw ShareApiError.unauthorized
+    default:
+      throw ShareApiError.serverError(http.statusCode)
+    }
+  }
+
+  private static func todayString() -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.locale = Locale(identifier: "ko_KR")
+    return formatter.string(from: Date())
+  }
+}
+
+enum ShareApiError: LocalizedError {
+  case unauthorized
+  case invalidResponse
+  case serverError(Int)
+
+  var errorDescription: String? {
+    switch self {
+    case .unauthorized:
+      return "인증이 만료되었습니다. 앱에서 다시 로그인해주세요."
+    case .invalidResponse:
+      return "서버 응답을 처리할 수 없습니다."
+    case .serverError(let code):
+      return "서버 오류가 발생했습니다. (\(code))"
+    }
+  }
+}

--- a/ios/Share Extension/ShareFolder.swift
+++ b/ios/Share Extension/ShareFolder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct ShareFolder {
+  let foldersId: Int
+  let title: String
+  let isDefault: Bool
+
+  init(foldersId: Int, title: String, isDefault: Bool = false) {
+    self.foldersId = foldersId
+    self.title = title
+    self.isDefault = isDefault
+  }
+
+  init?(json: [String: Any]) {
+    guard let id = json["foldersId"] as? Int,
+          let name = json["name"] as? String
+    else { return nil }
+    self.foldersId = id
+    self.title = name
+    self.isDefault = json["isDefault"] as? Bool ?? false
+  }
+}

--- a/ios/Share Extension/ShareViewController.swift
+++ b/ios/Share Extension/ShareViewController.swift
@@ -1,0 +1,791 @@
+import UIKit
+import UniformTypeIdentifiers
+
+final class ShareViewController: UIViewController {
+  private enum Constants {
+    static let maxMemoLength = 1000
+    static let chipHorizontalPadding: CGFloat = 18
+    static let chipVerticalPadding: CGFloat = 8
+    static let bottomPadding: CGFloat = 20
+  }
+
+  private var apiClient: ShareApiClient?
+  private var allFolders: [ShareFolder] = []
+  private var displayedFolders: [ShareFolder] = []
+  private var selectedFolder: ShareFolder?
+  private var sharedItemUrls: [URL] = []
+  private var isImage = true
+  private var isSaving = false
+
+  // MARK: - UI Elements
+
+  private let cardView: UIView = {
+    let v = UIView()
+    v.translatesAutoresizingMaskIntoConstraints = false
+    v.backgroundColor = .white
+    v.layer.cornerRadius = 24
+    v.layer.maskedCorners = [
+      .layerMinXMinYCorner, .layerMaxXMinYCorner
+    ]
+    v.clipsToBounds = true
+    return v
+  }()
+
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.text = "보관함"
+    label.textColor = UIColor(
+      red: 0.13, green: 0.13, blue: 0.13, alpha: 1
+    )
+    label.font = .systemFont(ofSize: 22, weight: .bold)
+    return label
+  }()
+
+  private lazy var saveButton: UIButton = {
+    let button = UIButton(type: .system)
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.setTitle("저장", for: .normal)
+    button.titleLabel?.font = .systemFont(
+      ofSize: 16, weight: .semibold
+    )
+    button.setTitleColor(
+      UIColor(
+        red: 0.22, green: 0.61, blue: 0.98, alpha: 1
+      ),
+      for: .normal
+    )
+    button.addTarget(
+      self, action: #selector(saveTapped),
+      for: .touchUpInside
+    )
+    return button
+  }()
+
+  private let loadingIndicator: UIActivityIndicatorView = {
+    let indicator = UIActivityIndicatorView(
+      style: .medium
+    )
+    indicator.translatesAutoresizingMaskIntoConstraints = false
+    indicator.hidesWhenStopped = true
+    return indicator
+  }()
+
+  private let searchContainerView: UIView = {
+    let v = UIView()
+    v.translatesAutoresizingMaskIntoConstraints = false
+    v.backgroundColor = UIColor(
+      red: 0.96, green: 0.97, blue: 0.98, alpha: 1
+    )
+    v.layer.cornerRadius = 14
+    return v
+  }()
+
+  private let searchIconView: UIImageView = {
+    let iv = UIImageView(
+      image: UIImage(systemName: "magnifyingglass")
+    )
+    iv.translatesAutoresizingMaskIntoConstraints = false
+    iv.tintColor = UIColor(
+      red: 0.13, green: 0.13, blue: 0.13, alpha: 1
+    )
+    return iv
+  }()
+
+  private lazy var searchTextField: UITextField = {
+    let tf = UITextField()
+    tf.translatesAutoresizingMaskIntoConstraints = false
+    tf.placeholder = "보관함 입력"
+    tf.font = .systemFont(ofSize: 16, weight: .semibold)
+    tf.textColor = UIColor(
+      red: 0.13, green: 0.13, blue: 0.13, alpha: 1
+    )
+    tf.clearButtonMode = .whileEditing
+    tf.addTarget(
+      self, action: #selector(searchTextChanged),
+      for: .editingChanged
+    )
+    return tf
+  }()
+
+  private lazy var chipsCollectionView: UICollectionView = {
+    let layout = UICollectionViewFlowLayout()
+    layout.scrollDirection = .horizontal
+    layout.minimumLineSpacing = 10
+    layout.minimumInteritemSpacing = 10
+    layout.sectionInset = .zero
+    let cv = UICollectionView(
+      frame: .zero, collectionViewLayout: layout
+    )
+    cv.translatesAutoresizingMaskIntoConstraints = false
+    cv.backgroundColor = .clear
+    cv.showsHorizontalScrollIndicator = false
+    cv.dataSource = self
+    cv.delegate = self
+    cv.register(
+      FolderChipCell.self,
+      forCellWithReuseIdentifier: FolderChipCell.reuseId
+    )
+    return cv
+  }()
+
+  private let memoHeaderIconView: UIImageView = {
+    let iv = UIImageView(
+      image: UIImage(systemName: "doc.text")
+    )
+    iv.translatesAutoresizingMaskIntoConstraints = false
+    iv.tintColor = UIColor(
+      red: 0.22, green: 0.61, blue: 0.98, alpha: 1
+    )
+    return iv
+  }()
+
+  private let memoHeaderLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.text = "메모(선택)"
+    label.textColor = UIColor(
+      red: 0.13, green: 0.13, blue: 0.13, alpha: 1
+    )
+    label.font = .systemFont(ofSize: 18, weight: .bold)
+    return label
+  }()
+
+  private let memoContainerView: UIView = {
+    let v = UIView()
+    v.translatesAutoresizingMaskIntoConstraints = false
+    v.backgroundColor = UIColor(
+      red: 0.96, green: 0.97, blue: 0.98, alpha: 1
+    )
+    v.layer.cornerRadius = 12
+    return v
+  }()
+
+  private lazy var memoTextView: UITextView = {
+    let tv = UITextView()
+    tv.translatesAutoresizingMaskIntoConstraints = false
+    tv.font = .systemFont(ofSize: 16, weight: .medium)
+    tv.textColor = UIColor(
+      red: 0.13, green: 0.13, blue: 0.13, alpha: 1
+    )
+    tv.backgroundColor = .clear
+    tv.textContainerInset = .zero
+    tv.textContainer.lineFragmentPadding = 0
+    tv.delegate = self
+    return tv
+  }()
+
+  private let memoPlaceholderLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.text = "자료에 대한 정보를 간단하게 메모해보세요."
+    label.textColor = UIColor(
+      red: 0.50, green: 0.51, blue: 0.61, alpha: 1
+    )
+    label.font = .systemFont(ofSize: 16, weight: .medium)
+    return label
+  }()
+
+  private let memoCounterLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.text = "0/1000"
+    label.textColor = UIColor(
+      red: 0.50, green: 0.51, blue: 0.61, alpha: 1
+    )
+    label.font = .systemFont(ofSize: 16, weight: .medium)
+    label.textAlignment = .right
+    return label
+  }()
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupLayout()
+    loadSharedItems()
+    initApiAndFetchFolders()
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+    clearSystemBackgrounds()
+  }
+
+  private func clearSystemBackgrounds() {
+    var current: UIView? = view.superview
+    while let sv = current {
+      sv.backgroundColor = .clear
+      current = sv.superview
+    }
+  }
+
+  // MARK: - API Init & Folder Fetch
+
+  private func initApiAndFetchFolders() {
+    guard let client = ShareApiClient() else {
+      showError("로그인 정보가 없습니다.\n앱에서 로그인 후 다시 시도해주세요.")
+      return
+    }
+    self.apiClient = client
+    loadingIndicator.startAnimating()
+    saveButton.isHidden = true
+
+    Task {
+      do {
+        let folders = try await client.fetchFolders()
+        await MainActor.run {
+          self.allFolders = folders
+          self.displayedFolders = folders
+          self.selectedFolder = folders.first(
+            where: { $0.isDefault }
+          ) ?? folders.first
+          self.chipsCollectionView.reloadData()
+          self.loadingIndicator.stopAnimating()
+          self.saveButton.isHidden = false
+        }
+      } catch let error as ShareApiError {
+        await MainActor.run {
+          self.loadingIndicator.stopAnimating()
+          self.showError(error.errorDescription ?? "오류 발생")
+        }
+      } catch {
+        await MainActor.run {
+          self.loadingIndicator.stopAnimating()
+          self.showError("보관함을 불러올 수 없습니다.")
+        }
+      }
+    }
+  }
+
+  // MARK: - Shared Item Loading
+
+  private func loadSharedItems() {
+    guard let item = extensionContext?.inputItems.first
+            as? NSExtensionItem,
+          let attachments = item.attachments
+    else { return }
+
+    let group = DispatchGroup()
+
+    for provider in attachments {
+      if provider.hasItemConformingToTypeIdentifier(
+        UTType.image.identifier
+      ) {
+        isImage = true
+        group.enter()
+        provider.loadItem(
+          forTypeIdentifier: UTType.image.identifier
+        ) { [weak self] item, _ in
+          defer { group.leave() }
+          if let url = item as? URL {
+            self?.sharedItemUrls.append(url)
+          }
+        }
+      } else if provider.hasItemConformingToTypeIdentifier(
+        UTType.data.identifier
+      ) {
+        isImage = false
+        group.enter()
+        provider.loadItem(
+          forTypeIdentifier: UTType.data.identifier
+        ) { [weak self] item, _ in
+          defer { group.leave() }
+          if let url = item as? URL {
+            self?.sharedItemUrls.append(url)
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Layout
+
+  private func setupLayout() {
+    view.backgroundColor = .clear
+
+    let dimTap = UITapGestureRecognizer(
+      target: self, action: #selector(cancelTapped)
+    )
+    dimTap.delegate = self
+    view.addGestureRecognizer(dimTap)
+
+    view.addSubview(cardView)
+
+    let headerStack = UIStackView(
+      arrangedSubviews: [titleLabel, saveButton]
+    )
+    headerStack.translatesAutoresizingMaskIntoConstraints
+      = false
+    headerStack.axis = .horizontal
+    headerStack.alignment = .center
+
+    cardView.addSubview(headerStack)
+    cardView.addSubview(loadingIndicator)
+    cardView.addSubview(searchContainerView)
+    searchContainerView.addSubview(searchIconView)
+    searchContainerView.addSubview(searchTextField)
+    cardView.addSubview(chipsCollectionView)
+    cardView.addSubview(memoHeaderIconView)
+    cardView.addSubview(memoHeaderLabel)
+    cardView.addSubview(memoContainerView)
+    memoContainerView.addSubview(memoTextView)
+    memoContainerView.addSubview(memoPlaceholderLabel)
+    cardView.addSubview(memoCounterLabel)
+
+    let safeBottom = view.safeAreaLayoutGuide.bottomAnchor
+
+    NSLayoutConstraint.activate([
+      cardView.leadingAnchor.constraint(
+        equalTo: view.leadingAnchor
+      ),
+      cardView.trailingAnchor.constraint(
+        equalTo: view.trailingAnchor
+      ),
+      cardView.bottomAnchor.constraint(
+        equalTo: view.bottomAnchor
+      ),
+
+      headerStack.topAnchor.constraint(
+        equalTo: cardView.topAnchor, constant: 16
+      ),
+      headerStack.leadingAnchor.constraint(
+        equalTo: cardView.leadingAnchor, constant: 20
+      ),
+      headerStack.trailingAnchor.constraint(
+        equalTo: cardView.trailingAnchor, constant: -20
+      ),
+
+      loadingIndicator.centerYAnchor.constraint(
+        equalTo: headerStack.centerYAnchor
+      ),
+      loadingIndicator.trailingAnchor.constraint(
+        equalTo: cardView.trailingAnchor, constant: -20
+      ),
+
+      searchContainerView.topAnchor.constraint(
+        equalTo: headerStack.bottomAnchor, constant: 18
+      ),
+      searchContainerView.leadingAnchor.constraint(
+        equalTo: cardView.leadingAnchor, constant: 20
+      ),
+      searchContainerView.trailingAnchor.constraint(
+        equalTo: cardView.trailingAnchor, constant: -20
+      ),
+      searchContainerView.heightAnchor.constraint(
+        equalToConstant: 56
+      ),
+
+      searchIconView.leadingAnchor.constraint(
+        equalTo: searchContainerView.leadingAnchor,
+        constant: 14
+      ),
+      searchIconView.centerYAnchor.constraint(
+        equalTo: searchContainerView.centerYAnchor
+      ),
+      searchIconView.widthAnchor.constraint(
+        equalToConstant: 24
+      ),
+      searchIconView.heightAnchor.constraint(
+        equalToConstant: 24
+      ),
+
+      searchTextField.leadingAnchor.constraint(
+        equalTo: searchIconView.trailingAnchor, constant: 10
+      ),
+      searchTextField.trailingAnchor.constraint(
+        equalTo: searchContainerView.trailingAnchor,
+        constant: -12
+      ),
+      searchTextField.centerYAnchor.constraint(
+        equalTo: searchContainerView.centerYAnchor
+      ),
+
+      chipsCollectionView.topAnchor.constraint(
+        equalTo: searchContainerView.bottomAnchor,
+        constant: 12
+      ),
+      chipsCollectionView.leadingAnchor.constraint(
+        equalTo: cardView.leadingAnchor, constant: 20
+      ),
+      chipsCollectionView.trailingAnchor.constraint(
+        equalTo: cardView.trailingAnchor, constant: -20
+      ),
+      chipsCollectionView.heightAnchor.constraint(
+        equalToConstant: 44
+      ),
+
+      memoHeaderIconView.topAnchor.constraint(
+        equalTo: chipsCollectionView.bottomAnchor,
+        constant: 22
+      ),
+      memoHeaderIconView.leadingAnchor.constraint(
+        equalTo: cardView.leadingAnchor, constant: 20
+      ),
+      memoHeaderIconView.widthAnchor.constraint(
+        equalToConstant: 20
+      ),
+      memoHeaderIconView.heightAnchor.constraint(
+        equalToConstant: 20
+      ),
+
+      memoHeaderLabel.leadingAnchor.constraint(
+        equalTo: memoHeaderIconView.trailingAnchor,
+        constant: 8
+      ),
+      memoHeaderLabel.centerYAnchor.constraint(
+        equalTo: memoHeaderIconView.centerYAnchor
+      ),
+
+      memoContainerView.topAnchor.constraint(
+        equalTo: memoHeaderIconView.bottomAnchor,
+        constant: 10
+      ),
+      memoContainerView.leadingAnchor.constraint(
+        equalTo: cardView.leadingAnchor, constant: 20
+      ),
+      memoContainerView.trailingAnchor.constraint(
+        equalTo: cardView.trailingAnchor, constant: -20
+      ),
+      memoContainerView.heightAnchor.constraint(
+        equalToConstant: 120
+      ),
+
+      memoTextView.topAnchor.constraint(
+        equalTo: memoContainerView.topAnchor, constant: 13
+      ),
+      memoTextView.leadingAnchor.constraint(
+        equalTo: memoContainerView.leadingAnchor,
+        constant: 13
+      ),
+      memoTextView.trailingAnchor.constraint(
+        equalTo: memoContainerView.trailingAnchor,
+        constant: -13
+      ),
+      memoTextView.bottomAnchor.constraint(
+        equalTo: memoContainerView.bottomAnchor,
+        constant: -13
+      ),
+
+      memoPlaceholderLabel.topAnchor.constraint(
+        equalTo: memoContainerView.topAnchor, constant: 13
+      ),
+      memoPlaceholderLabel.leadingAnchor.constraint(
+        equalTo: memoContainerView.leadingAnchor,
+        constant: 13
+      ),
+      memoPlaceholderLabel.trailingAnchor.constraint(
+        equalTo: memoContainerView.trailingAnchor,
+        constant: -13
+      ),
+
+      memoCounterLabel.topAnchor.constraint(
+        equalTo: memoContainerView.bottomAnchor,
+        constant: 10
+      ),
+      memoCounterLabel.trailingAnchor.constraint(
+        equalTo: cardView.trailingAnchor, constant: -20
+      ),
+      memoCounterLabel.leadingAnchor.constraint(
+        equalTo: cardView.leadingAnchor, constant: 20
+      ),
+
+      memoCounterLabel.bottomAnchor.constraint(
+        equalTo: safeBottom,
+        constant: -Constants.bottomPadding
+      ),
+    ])
+  }
+
+  // MARK: - Actions
+
+  @objc
+  private func searchTextChanged() {
+    let keyword = searchTextField.text?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      ?? ""
+    let matched = keyword.isEmpty
+      ? allFolders
+      : allFolders.filter {
+          $0.title.localizedCaseInsensitiveContains(keyword)
+        }
+
+    if keyword.isEmpty || !matched.isEmpty {
+      displayedFolders = matched
+      chipsCollectionView.reloadData()
+    }
+  }
+
+  @objc
+  private func saveTapped() {
+    guard !isSaving else { return }
+    guard let client = apiClient else {
+      showError("로그인 정보가 없습니다.")
+      return
+    }
+    guard let folder = selectedFolder else {
+      showError("보관함을 선택해주세요.")
+      return
+    }
+    guard !sharedItemUrls.isEmpty else {
+      showError("공유된 파일이 없습니다.")
+      return
+    }
+
+    isSaving = true
+    saveButton.isEnabled = false
+    loadingIndicator.startAnimating()
+
+    let memo = memoTextView.text ?? ""
+    let urls = sharedItemUrls
+    let uploadAsImage = isImage
+
+    Task {
+      do {
+        for url in urls {
+          let data = try Data(contentsOf: url)
+          let fileName = url.lastPathComponent
+
+          if uploadAsImage {
+            try await client.uploadImage(
+              data: data,
+              fileName: fileName,
+              folderId: folder.foldersId,
+              textContent: memo
+            )
+          } else {
+            try await client.uploadFile(
+              data: data,
+              fileName: fileName,
+              folderId: folder.foldersId,
+              textContent: memo
+            )
+          }
+        }
+
+        await MainActor.run {
+          self.openAppAndComplete(
+            folderId: folder.foldersId,
+            folderName: folder.title
+          )
+        }
+      } catch {
+        await MainActor.run {
+          self.isSaving = false
+          self.saveButton.isEnabled = true
+          self.loadingIndicator.stopAnimating()
+          self.showError(
+            error.localizedDescription
+          )
+        }
+      }
+    }
+  }
+
+  @objc
+  private func cancelTapped() {
+    extensionContext?.cancelRequest(
+      withError: NSError(
+        domain: "com.example.pojTodo.share",
+        code: 0,
+        userInfo: nil
+      )
+    )
+  }
+
+  // MARK: - Navigation
+
+  private func openAppAndComplete(
+    folderId: Int,
+    folderName: String
+  ) {
+    let tab = isImage ? "images" : "files"
+    let encodedName = folderName.addingPercentEncoding(
+      withAllowedCharacters: .urlQueryAllowed
+    ) ?? folderName
+
+    let urlString = "toit://folder"
+      + "?id=\(folderId)"
+      + "&name=\(encodedName)"
+      + "&tab=\(tab)"
+
+    if let url = URL(string: urlString) {
+      var responder: UIResponder? = self
+      while let r = responder {
+        if let app = r as? UIApplication {
+          app.open(url)
+          break
+        }
+        responder = r.next
+      }
+    }
+
+    extensionContext?.completeRequest(
+      returningItems: [], completionHandler: nil
+    )
+  }
+
+  // MARK: - Error
+
+  private func showError(_ message: String) {
+    let alert = UIAlertController(
+      title: nil, message: message,
+      preferredStyle: .alert
+    )
+    alert.addAction(UIAlertAction(
+      title: "확인", style: .default
+    ) { [weak self] _ in
+      self?.cancelTapped()
+    })
+    present(alert, animated: true)
+  }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension ShareViewController: UIGestureRecognizerDelegate {
+  func gestureRecognizer(
+    _ gestureRecognizer: UIGestureRecognizer,
+    shouldReceive touch: UITouch
+  ) -> Bool {
+    let location = touch.location(in: view)
+    return !cardView.frame.contains(location)
+  }
+}
+
+// MARK: - UICollectionView DataSource & Delegate
+
+extension ShareViewController:
+  UICollectionViewDataSource,
+  UICollectionViewDelegateFlowLayout
+{
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    return displayedFolders.count
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: FolderChipCell.reuseId,
+      for: indexPath
+    ) as? FolderChipCell else {
+      return UICollectionViewCell()
+    }
+
+    let folder = displayedFolders[indexPath.item]
+    cell.configure(
+      title: folder.title,
+      isSelected: folder.foldersId
+        == selectedFolder?.foldersId
+    )
+    return cell
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    selectedFolder = displayedFolders[indexPath.item]
+    collectionView.reloadData()
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    layout collectionViewLayout: UICollectionViewLayout,
+    sizeForItemAt indexPath: IndexPath
+  ) -> CGSize {
+    let title = displayedFolders[indexPath.item].title
+    let attrs: [NSAttributedString.Key: Any] = [
+      .font: UIFont.systemFont(
+        ofSize: 16, weight: .semibold
+      ),
+    ]
+    let width = title.size(withAttributes: attrs).width
+    return CGSize(
+      width: width + (Constants.chipHorizontalPadding * 2),
+      height: Constants.chipVerticalPadding * 2 + 22
+    )
+  }
+}
+
+// MARK: - UITextView Delegate
+
+extension ShareViewController: UITextViewDelegate {
+  func textViewDidChange(_ textView: UITextView) {
+    if textView.text.count > Constants.maxMemoLength {
+      textView.text = String(
+        textView.text.prefix(Constants.maxMemoLength)
+      )
+    }
+    memoPlaceholderLabel.isHidden = !textView.text.isEmpty
+    memoCounterLabel.text =
+      "\(textView.text.count)/\(Constants.maxMemoLength)"
+  }
+}
+
+// MARK: - FolderChipCell
+
+private final class FolderChipCell: UICollectionViewCell {
+  static let reuseId = "FolderChipCell"
+
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.font = .systemFont(ofSize: 16, weight: .semibold)
+    return label
+  }()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    contentView.layer.cornerRadius = 22
+    contentView.layer.borderWidth = 1
+    contentView.addSubview(titleLabel)
+
+    NSLayoutConstraint.activate([
+      titleLabel.leadingAnchor.constraint(
+        equalTo: contentView.leadingAnchor, constant: 18
+      ),
+      titleLabel.trailingAnchor.constraint(
+        equalTo: contentView.trailingAnchor, constant: -18
+      ),
+      titleLabel.topAnchor.constraint(
+        equalTo: contentView.topAnchor, constant: 8
+      ),
+      titleLabel.bottomAnchor.constraint(
+        equalTo: contentView.bottomAnchor, constant: -8
+      ),
+    ])
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func configure(title: String, isSelected: Bool) {
+    titleLabel.text = title
+    if isSelected {
+      contentView.backgroundColor = UIColor(
+        red: 0.22, green: 0.61, blue: 0.98, alpha: 0.14
+      )
+      contentView.layer.borderColor = UIColor(
+        red: 0.22, green: 0.61, blue: 0.98, alpha: 1
+      ).cgColor
+      titleLabel.textColor = UIColor(
+        red: 0.22, green: 0.61, blue: 0.98, alpha: 1
+      )
+    } else {
+      contentView.backgroundColor = .white
+      contentView.layer.borderColor = UIColor(
+        red: 0.87, green: 0.87, blue: 0.87, alpha: 1
+      ).cgColor
+      titleLabel.textColor = UIColor(
+        red: 0.50, green: 0.51, blue: 0.61, alpha: 1
+      )
+    }
+  }
+}

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -77,6 +77,7 @@ class AuthController extends Notifier<AuthState> {
         status: AuthStatus.authenticated,
         userId: userId,
       );
+      await _authService.syncExistingTokenToAppGroup();
     } else {
       state = const AuthState(
         status: AuthStatus.unauthenticated,

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,6 +1,8 @@
 import 'package:dio/dio.dart';
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
@@ -45,6 +47,10 @@ class AuthService {
   final FlutterSecureStorage _storage;
   final Dio _dio;
 
+  static const _tokenChannel = MethodChannel(
+    'com.example.pojTodo/token',
+  );
+
   AuthService({FlutterSecureStorage? storage, Dio? dio})
     : _storage = storage ?? const FlutterSecureStorage(),
       _dio =
@@ -71,6 +77,7 @@ class AuthService {
       _storage.write(key: _kAccessToken, value: accessToken),
       _storage.write(key: _kRefreshToken, value: refreshToken),
     ]);
+    await _syncTokenToAppGroup(accessToken);
   }
 
   Future<String?> getAccessToken() => _storage.read(key: _kAccessToken);
@@ -82,11 +89,61 @@ class AuthService {
     return token != null && token.isNotEmpty;
   }
 
+  /// 앱 시작 시 기존 토큰을 App Group에 1회 동기화
+  Future<void> syncExistingTokenToAppGroup() async {
+    final token = await getAccessToken();
+    if (token != null && token.isNotEmpty) {
+      await _syncTokenToAppGroup(token);
+    }
+  }
+
   Future<void> clearTokens() async {
     await Future.wait([
       _storage.delete(key: _kAccessToken),
       _storage.delete(key: _kRefreshToken),
     ]);
+    await _clearTokenFromAppGroup();
+  }
+
+  // ─── iOS App Group 토큰 동기화 (Share Extension용) ───
+
+  Future<void> _syncTokenToAppGroup(String accessToken) async {
+    if (!Platform.isIOS) return;
+    try {
+      final userId = await getUserIdFromToken();
+      debugPrint(
+        '[AuthService] App Group 동기화 시도 - '
+        'token: ${accessToken.substring(0, 10)}..., '
+        'userId: $userId, '
+        'baseUrl: ${ApiConstants.baseUrl}',
+      );
+      final result = await _tokenChannel.invokeMethod(
+        'syncToken',
+        {
+          'accessToken': accessToken,
+          'userId': userId ?? 0,
+          'baseUrl': ApiConstants.baseUrl,
+        },
+      );
+      debugPrint(
+        '[AuthService] App Group 동기화 결과: $result',
+      );
+    } catch (e) {
+      debugPrint(
+        '[AuthService] App Group 토큰 동기화 실패: $e',
+      );
+    }
+  }
+
+  Future<void> _clearTokenFromAppGroup() async {
+    if (!Platform.isIOS) return;
+    try {
+      await _tokenChannel.invokeMethod('clearToken');
+    } catch (e) {
+      debugPrint(
+        '[AuthService] App Group 토큰 삭제 실패: $e',
+      );
+    }
   }
 
   // ─── 소셜 로그인 (백엔드 OAuth, 콜백 규약 동일) ───
@@ -218,6 +275,7 @@ class AuthService {
       }
 
       await _storage.write(key: _kAccessToken, value: newAccessToken);
+      await _syncTokenToAppGroup(newAccessToken);
       debugPrint('[AuthService] 액세스 토큰 재발급 성공');
       return newAccessToken;
     } on DioException catch (e) {

--- a/lib/views/screens/navigation_shell.dart
+++ b/lib/views/screens/navigation_shell.dart
@@ -1,8 +1,19 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
 import '../../controllers/home_controller.dart';
+import '../../core/constants/folder_tab_index.dart';
+import '../../models/home/folder_item.dart';
+import '../../repositories/home_repository.dart';
 import '../widgets/common/custom_bottom_nav_bar.dart';
+import '../widgets/common/share_save_bottom_sheet.dart';
+import 'folder_detail_screen.dart';
 import 'home_screen.dart';
 import 'calendar_screen.dart';
 import 'save_link_screen.dart';
@@ -15,11 +26,230 @@ import 'event_form_screen.dart';
 final currentTabIndexProvider = StateProvider<int>((ref) => 0);
 
 /// 네비게이션 쉘 (하단 네비바 + 화면 전환 관리)
-class NavigationShell extends ConsumerWidget {
+class NavigationShell extends ConsumerStatefulWidget {
   const NavigationShell({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<NavigationShell> createState() => _NavigationShellState();
+}
+
+class _NavigationShellState extends ConsumerState<NavigationShell> {
+  static const _deepLinkChannel = MethodChannel(
+    'com.example.pojTodo/deeplink',
+  );
+
+  StreamSubscription<List<SharedMediaFile>>? _shareMediaSubscription;
+  bool _isShareSheetVisible = false;
+  bool _isInitialShareChecked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _deepLinkChannel.setMethodCallHandler(_handleDeepLink);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _bindShareReceiver();
+    });
+  }
+
+  @override
+  void dispose() {
+    _deepLinkChannel.setMethodCallHandler(null);
+    _shareMediaSubscription?.cancel();
+    super.dispose();
+  }
+
+  Future<dynamic> _handleDeepLink(MethodCall call) async {
+    if (call.method != 'onDeepLink') return;
+    final urlString = call.arguments as String?;
+    if (urlString == null) return;
+
+    final uri = Uri.tryParse(urlString);
+    if (uri == null || uri.host != 'folder') return;
+
+    final folderId = int.tryParse(
+      uri.queryParameters['id'] ?? '',
+    );
+    final folderName = uri.queryParameters['name'] ?? '보관함';
+    final tabName = uri.queryParameters['tab'] ?? 'links';
+
+    if (folderId == null) return;
+
+    final initialTab = switch (tabName) {
+      'images' => FolderTab.images,
+      'files' => FolderTab.files,
+      'notes' => FolderTab.notes,
+      _ => FolderTab.links,
+    };
+
+    if (!mounted) return;
+
+    await ref.read(homeProvider.notifier).refresh();
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => FolderDetailScreen(
+          foldersId: folderId,
+          folderName: folderName,
+          initialTab: initialTab,
+        ),
+      ),
+    );
+  }
+
+  void _bindShareReceiver() {
+    _shareMediaSubscription = ReceiveSharingIntent.instance
+        .getMediaStream()
+        .listen(
+          (mediaFiles) => _handleSharedMedia(mediaFiles),
+          onError: (_) {},
+        );
+    _checkInitialSharedMedia();
+  }
+
+  Future<void> _checkInitialSharedMedia() async {
+    if (_isInitialShareChecked) return;
+    _isInitialShareChecked = true;
+    final mediaFiles = await ReceiveSharingIntent.instance.getInitialMedia();
+    await _handleSharedMedia(mediaFiles);
+  }
+
+  Future<void> _handleSharedMedia(List<SharedMediaFile> mediaFiles) async {
+    if (!mounted || _isShareSheetVisible || mediaFiles.isEmpty) return;
+
+    final sharedImagePaths = mediaFiles
+        .map((file) => _normalizeFilePath(file.path))
+        .where(_isImagePath)
+        .toList();
+
+    if (sharedImagePaths.isEmpty) return;
+
+    _isShareSheetVisible = true;
+    try {
+      final folders = await _ensureFolderList();
+      if (!mounted) return;
+
+      if (folders.isEmpty) {
+        _showSnackBar('보관함이 없어 공유 이미지를 저장할 수 없습니다.');
+        return;
+      }
+
+      await showShareSaveBottomSheet(
+        context,
+        folders: folders,
+        initialSelectedFolder: folders.where((f) => f.isDefault).firstOrNull,
+        onSave: (selectedFolder, memo) async {
+          await _saveSharedImages(
+            imagePaths: sharedImagePaths,
+            selectedFolder: selectedFolder,
+            memo: memo,
+          );
+        },
+      );
+    } finally {
+      _isShareSheetVisible = false;
+      ReceiveSharingIntent.instance.reset();
+    }
+  }
+
+  Future<List<FolderItem>> _ensureFolderList() async {
+    var state = ref.read(homeProvider);
+    if (state.folders.isNotEmpty) return state.folders;
+
+    await ref.read(homeProvider.notifier).refresh();
+    state = ref.read(homeProvider);
+    return state.folders;
+  }
+
+  Future<void> _saveSharedImages({
+    required List<String> imagePaths,
+    required FolderItem selectedFolder,
+    required String memo,
+  }) async {
+    final repository = ref.read(homeRepositoryProvider);
+    int savedCount = 0;
+    String? failReason;
+
+    for (final imagePath in imagePaths) {
+      final file = File(imagePath);
+      if (!await file.exists()) {
+        failReason = '이미지 파일을 찾을 수 없습니다.';
+        continue;
+      }
+
+      List<int> imageBytes;
+      try {
+        imageBytes = await file.readAsBytes();
+      } catch (_) {
+        failReason = '이미지 파일을 읽을 수 없습니다.';
+        continue;
+      }
+      if (imageBytes.isEmpty) {
+        failReason = '이미지 파일을 읽을 수 없습니다.';
+        continue;
+      }
+
+      try {
+        await repository.createImage(
+          foldersIdList: [selectedFolder.foldersId],
+          textContent: memo,
+          imageBytes: imageBytes,
+          fileName: _extractFileName(imagePath),
+        );
+        savedCount++;
+      } on DioException catch (_) {
+        failReason = '이미지 저장 중 오류가 발생했습니다.';
+      } catch (_) {
+        failReason = '이미지 저장에 실패했습니다.';
+      }
+    }
+
+    if (savedCount <= 0) {
+      _showSnackBar(failReason ?? '공유 이미지 저장에 실패했습니다.');
+      throw Exception('Failed to save shared images.');
+    }
+
+    await ref.read(homeProvider.notifier).refresh();
+    ref.invalidate(pageItemsProvider(selectedFolder.foldersId));
+    _showSnackBar(
+      savedCount == imagePaths.length
+          ? '공유 이미지가 저장되었습니다.'
+          : '$savedCount장 저장됨. 일부 실패.',
+    );
+  }
+
+  String _normalizeFilePath(String rawPath) {
+    if (rawPath.startsWith('file://')) {
+      return Uri.parse(rawPath).toFilePath();
+    }
+    return rawPath;
+  }
+
+  bool _isImagePath(String path) {
+    final lowerPath = path.toLowerCase();
+    return lowerPath.endsWith('.jpg') ||
+        lowerPath.endsWith('.jpeg') ||
+        lowerPath.endsWith('.png') ||
+        lowerPath.endsWith('.webp') ||
+        lowerPath.endsWith('.gif') ||
+        lowerPath.endsWith('.heic') ||
+        lowerPath.endsWith('.heif');
+  }
+
+  String _extractFileName(String path) {
+    final normalized = path.replaceAll('\\', '/');
+    final parts = normalized.split('/');
+    return parts.isEmpty ? 'shared_image.jpg' : parts.last;
+  }
+
+  void _showSnackBar(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final currentIndex = ref.watch(currentTabIndexProvider);
 
     return Scaffold(
@@ -38,19 +268,19 @@ class NavigationShell extends ConsumerWidget {
         onAddMenuTap: (menuIndex) {
           switch (menuIndex) {
             case 0:
-              Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => const SaveLinkScreen()),
-              );
+              Navigator.of(
+                context,
+              ).push(MaterialPageRoute(builder: (_) => const SaveLinkScreen()));
               break;
             case 1:
-              Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => const SaveNoteScreen()),
-              );
+              Navigator.of(
+                context,
+              ).push(MaterialPageRoute(builder: (_) => const SaveNoteScreen()));
               break;
             case 2:
-              Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => const SaveFileScreen()),
-              );
+              Navigator.of(
+                context,
+              ).push(MaterialPageRoute(builder: (_) => const SaveFileScreen()));
               break;
             case 3:
               Navigator.of(context).push(
@@ -60,15 +290,13 @@ class NavigationShell extends ConsumerWidget {
             case 4:
               Navigator.of(context)
                   .push(
-                    MaterialPageRoute(
-                      builder: (_) => const EventFormScreen(),
-                    ),
+                    MaterialPageRoute(builder: (_) => const EventFormScreen()),
                   )
                   .then((result) {
-                if (result != null) {
-                  ref.read(currentTabIndexProvider.notifier).state = 1;
-                }
-              });
+                    if (result != null) {
+                      ref.read(currentTabIndexProvider.notifier).state = 1;
+                    }
+                  });
               break;
           }
         },

--- a/lib/views/widgets/common/share_save_bottom_sheet.dart
+++ b/lib/views/widgets/common/share_save_bottom_sheet.dart
@@ -1,0 +1,355 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../../../core/constants/app_assets.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../models/home/folder_item.dart';
+
+/// 외부 공유 진입 시 저장 바텀시트를 표시
+Future<void> showShareSaveBottomSheet(
+  BuildContext context, {
+  required List<FolderItem> folders,
+  FolderItem? initialSelectedFolder,
+  String initialMemo = '',
+  required Future<void> Function(FolderItem selectedFolder, String memo) onSave,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    backgroundColor: Colors.transparent,
+    builder: (_) => ShareSaveBottomSheet(
+      folders: folders,
+      initialSelectedFolder: initialSelectedFolder,
+      initialMemo: initialMemo,
+      onSave: onSave,
+    ),
+  );
+}
+
+/// 외부 공유 진입 전용 저장 바텀시트.
+class ShareSaveBottomSheet extends StatefulWidget {
+  const ShareSaveBottomSheet({
+    super.key,
+    required this.folders,
+    this.initialSelectedFolder,
+    this.initialMemo = '',
+    required this.onSave,
+  });
+
+  final List<FolderItem> folders;
+  final FolderItem? initialSelectedFolder;
+  final String initialMemo;
+  final Future<void> Function(FolderItem selectedFolder, String memo) onSave;
+
+  @override
+  State<ShareSaveBottomSheet> createState() => _ShareSaveBottomSheetState();
+}
+
+class _ShareSaveBottomSheetState extends State<ShareSaveBottomSheet> {
+  static const int memoMaxLength = 1000;
+  static const double sheetFixedHeight = 420;
+  static const double folderChipAreaHeight = 44;
+
+  final folderSearchController = TextEditingController();
+  late final TextEditingController memoController;
+
+  FolderItem? selectedFolder;
+  late List<FolderItem> displayedFolders;
+  String folderQuery = '';
+  int memoLength = 0;
+  bool isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    memoController = TextEditingController(text: widget.initialMemo);
+    memoLength = widget.initialMemo.length;
+    selectedFolder = widget.initialSelectedFolder ?? widget.folders.firstOrNull;
+    displayedFolders = List<FolderItem>.from(widget.folders);
+
+    folderSearchController.addListener(_handleFolderSearchChanged);
+    memoController.addListener(() {
+      setState(() => memoLength = memoController.text.length);
+    });
+  }
+
+  @override
+  void dispose() {
+    folderSearchController.dispose();
+    memoController.dispose();
+    super.dispose();
+  }
+
+  Future<void> handleSaveTap() async {
+    if (isSaving) return;
+    final targetFolder = selectedFolder;
+    if (targetFolder == null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('보관함을 선택해 주세요.')));
+      return;
+    }
+
+    setState(() => isSaving = true);
+    try {
+      await widget.onSave(targetFolder, memoController.text.trim());
+      if (!mounted) return;
+      Navigator.of(context).pop();
+    } finally {
+      if (mounted) setState(() => isSaving = false);
+    }
+  }
+
+  void clearFolderSearch() {
+    if (folderSearchController.text.isEmpty) return;
+    folderSearchController.clear();
+  }
+
+  void _handleFolderSearchChanged() {
+    final nextQuery = folderSearchController.text;
+    final keyword = nextQuery.trim().toLowerCase();
+    final matchedFolders = keyword.isEmpty
+        ? widget.folders
+        : widget.folders.where((folder) {
+            return folder.title.toLowerCase().contains(keyword);
+          }).toList();
+
+    setState(() {
+      folderQuery = nextQuery;
+      if (keyword.isEmpty || matchedFolders.isNotEmpty) {
+        displayedFolders = List<FolderItem>.from(matchedFolders);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: Padding(
+        padding: EdgeInsets.only(bottom: bottomInset),
+        child: SizedBox(
+          height: sheetFixedHeight,
+          child: Container(
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+            ),
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Expanded(
+                      child: Text(
+                        '보관함',
+                        style: TextStyle(
+                          fontSize: 22,
+                          fontWeight: FontWeight.w700,
+                          color: AppColors.gray900,
+                        ),
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: handleSaveTap,
+                      behavior: HitTestBehavior.opaque,
+                      child: isSaving
+                          ? const SizedBox(
+                              width: 20,
+                              height: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Text(
+                              '저장',
+                              style: TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w600,
+                                color: selectedFolder == null
+                                    ? AppColors.neutral100
+                                    : AppColors.blue500,
+                              ),
+                            ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 18),
+                _buildFolderSearchBar(),
+                const SizedBox(height: 12),
+                _buildFolderChips(),
+                const SizedBox(height: 20),
+                Row(
+                  children: [
+                    SvgPicture.asset(
+                      AppAssets.noteIcon,
+                      width: 20,
+                      height: 20,
+                      colorFilter: const ColorFilter.mode(
+                        AppColors.blue500,
+                        BlendMode.srcIn,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    const Text(
+                      '메모(선택)',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.gray900,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                Container(
+                  height: 120,
+                  decoration: BoxDecoration(
+                    color: AppColors.neutral300,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  padding: const EdgeInsets.all(13),
+                  child: TextField(
+                    controller: memoController,
+                    maxLines: null,
+                    maxLength: memoMaxLength,
+                    expands: true,
+                    textAlignVertical: TextAlignVertical.top,
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                      color: AppColors.gray900,
+                      letterSpacing: -0.025 * 16,
+                      height: 1.5,
+                    ),
+                    decoration: const InputDecoration(
+                      border: InputBorder.none,
+                      hintText: '자료에 대한 정보를 간단하게 메모해보세요.',
+                      hintStyle: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                        color: AppColors.gray600,
+                        letterSpacing: -0.025 * 16,
+                        height: 1.5,
+                      ),
+                      contentPadding: EdgeInsets.zero,
+                      counterText: '',
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    '$memoLength/$memoMaxLength',
+                    style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                      color: AppColors.gray600,
+                      letterSpacing: -0.025 * 16,
+                      height: 1.25,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFolderSearchBar() {
+    return Container(
+      height: 56,
+      decoration: BoxDecoration(
+        color: AppColors.neutral300,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 14),
+      child: Row(
+        children: [
+          const Icon(Icons.search, size: 28, color: AppColors.gray900),
+          const SizedBox(width: 10),
+          Expanded(
+            child: TextField(
+              controller: folderSearchController,
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: AppColors.gray900,
+                letterSpacing: -0.025 * 16,
+                height: 1.4,
+              ),
+              decoration: const InputDecoration(
+                border: InputBorder.none,
+                hintText: '보관함 입력',
+                hintStyle: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.gray600,
+                  letterSpacing: -0.025 * 16,
+                  height: 1.4,
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+            onPressed: clearFolderSearch,
+            splashRadius: 20,
+            icon: Icon(
+              Icons.cancel_outlined,
+              size: 30,
+              color: folderQuery.trim().isEmpty
+                  ? AppColors.neutral100
+                  : AppColors.gray600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFolderChips() {
+    return SizedBox(
+      height: folderChipAreaHeight,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: displayedFolders.length,
+        separatorBuilder: (context, index) => const SizedBox(width: 10),
+        itemBuilder: (context, index) {
+          final folder = displayedFolders[index];
+          final isSelected = selectedFolder?.foldersId == folder.foldersId;
+          return InkWell(
+            borderRadius: BorderRadius.circular(999),
+            onTap: () => setState(() => selectedFolder = folder),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 8),
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? AppColors.blue500.withValues(alpha: 0.14)
+                    : Colors.white,
+                borderRadius: BorderRadius.circular(999),
+                border: Border.all(
+                  color: isSelected ? AppColors.blue500 : AppColors.neutral100,
+                ),
+              ),
+              child: Text(
+                folder.title,
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                  color: isSelected ? AppColors.blue500 : AppColors.gray600,
+                  letterSpacing: -0.025 * 16,
+                  height: 1.4,
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -840,6 +840,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  receive_sharing_intent:
+    dependency: "direct main"
+    description:
+      name: receive_sharing_intent
+      sha256: ec76056e4d258ad708e76d85591d933678625318e411564dcb9059048ca3a593
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.1"
   riverpod:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   file_picker: ^8.0.0
   flutter_web_auth_2: ^5.0.1
   flutter_secure_storage: ^10.0.0
+  receive_sharing_intent: ^1.8.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- iOS Share Extension 추가 (보관함 선택 · 메모 입력 · 이미지 업로드 UI)
- App Group을 통한 Flutter ↔ Share Extension 인증 토큰 공유 (TokenBridge)
- Android intent-filter로 이미지 공유 수신 지원
- receive_sharing_intent 패키지 연동 및 앱 내 공유 이미지 저장 플로우 구현
- 공유 저장 바텀시트(ShareSaveBottomSheet) 위젯 추가
- Share Extension에서 저장 완료 후 딥링크로 앱 내 해당 보관함 이동