### PR TITLE
feat: 알림 페이지 API 연동 및 UI 구성

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -171,27 +171,27 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
+  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
-  firebase_core: 8d5e24676350f15dd111aa59a88a1ae26605f9ba
-  firebase_messaging: 834cfc0887393d3108cdb19da8e57655c54fd0e4
+  firebase_core: ee30637e6744af8e0c12a6a1e8a9718506ec2398
+  firebase_messaging: 343de01a8d3e18b60df0c6d37f7174c44ae38e02
   FirebaseCore: 0dbad74bda10b8fb9ca34ad8f375fb9dd3ebef7c
   FirebaseCoreInternal: fe5fa466aeb314787093a7dce9f0beeaad5a2a21
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseMessaging: 7f42cfd10ec64181db4e01b305a613791c8e782c
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
-  flutter_web_auth_2: 4091f1645696258ddc57849f62bef2a848fc313c
+  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
+  flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
+  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  receive_sharing_intent: 79c848f5b045674ad60b9fea3bafea59962ad2c1
+  receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
 
 PODFILE CHECKSUM: 9e96353205564ae51eaf5422c660a3c602958b89
 

--- a/lib/controllers/notifications_page_controller.dart
+++ b/lib/controllers/notifications_page_controller.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/constants/api_constants.dart';
+import '../core/network/api_client.dart';
+import '../models/dto/notifications_page_response_dto.dart';
+
+Future<NotificationsPageResponseDto> _fetchNotificationsPage(Ref ref) async {
+  final apiClient = ref.read(apiClientProvider);
+  final response = await apiClient.get(ApiConstants.notificationsEndpoint);
+  final body = response.data;
+  final Map<String, dynamic> jsonMap;
+  if (body is Map<String, dynamic>) {
+    jsonMap = body;
+  } else if (body is Map) {
+    jsonMap = Map<String, dynamic>.from(body);
+  } else if (body is List<dynamic>) {
+    jsonMap = <String, dynamic>{'notifications': body};
+  } else {
+    throw StateError(
+      'Unexpected /page/notifications body: ${body.runtimeType}',
+    );
+  }
+  return NotificationsPageResponseDto.fromJson(jsonMap);
+}
+
+/// 알림 목록 (GET) + 탭 시 읽음 PATCH, 로컬 먼저 반영
+class NotificationsPageNotifier
+    extends StateNotifier<AsyncValue<NotificationsPageResponseDto>> {
+  NotificationsPageNotifier(this._ref, this._cacheKey)
+    : super(const AsyncValue.loading()) {
+    _load();
+  }
+
+  final Ref _ref;
+  final (int, int) _cacheKey;
+
+  Future<void> _load() async {
+    final (_, refreshTick) = _cacheKey;
+    if (refreshTick < 0) {
+      state = AsyncValue.error(
+        StateError('Invalid refresh tick: $refreshTick'),
+        StackTrace.current,
+      );
+      return;
+    }
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() => _fetchNotificationsPage(_ref));
+  }
+
+  /// 당김 새로고침·에러 재시도
+  Future<void> refresh() async {
+    await _load();
+  }
+
+  /// 미읽음이면 UI를 즉시 읽음으로 바꾼 뒤 PATCH (실패 시 롤백)
+  void scheduleMarkReadIfUnread(int notificationId) {
+    final data = state.value;
+    if (data == null) return;
+
+    NotificationItemDto? target;
+    for (final n in data.notifications) {
+      if (n.notificationId == notificationId) {
+        target = n;
+        break;
+      }
+    }
+    if (target == null || target.isRead) return;
+
+    final previous = data;
+    final updated = previous.copyWith(
+      notifications: [
+        for (final n in previous.notifications)
+          if (n.notificationId == notificationId)
+            n.copyWith(isRead: true)
+          else
+            n,
+      ],
+    );
+    state = AsyncValue.data(updated);
+
+    Future(() async {
+      try {
+        await _ref
+            .read(apiClientProvider)
+            .patch<void>(ApiConstants.notificationReadPath(notificationId));
+      } catch (_) {
+        try {
+          state = AsyncValue.data(previous);
+        } on Object {
+          // Provider 해제 직후 등 상태 반영 불가 시 무시
+        }
+      }
+    });
+  }
+}
+
+/// 세션·사용자 전환 시 `cacheKey`로 캐시 분리
+final notificationsPageProvider =
+    StateNotifierProvider.family<
+      NotificationsPageNotifier,
+      AsyncValue<NotificationsPageResponseDto>,
+      (int, int)
+    >((ref, key) {
+      return NotificationsPageNotifier(ref, key);
+    });

--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -37,6 +37,10 @@ class ApiConstants {
   /// 알림 목록 (GET /page/notifications)
   static const String notificationsEndpoint = '/page/notifications';
 
+  /// 알림 읽음 (PATCH /api/notifications/{id}/read)
+  static String notificationReadPath(int notificationId) =>
+      '/api/notifications/$notificationId/read';
+
   /// 자료 링크 추가 (POST)
   static const String linksEndpoint = '/links';
 

--- a/lib/models/dto/notifications_page_response_dto.dart
+++ b/lib/models/dto/notifications_page_response_dto.dart
@@ -1,4 +1,8 @@
 // GET /page/notifications 응답 및 알림 항목 DTO
+//
+// 루트: `{ notifications: [...] }` 또는 `{ data: { notifications: [...] } }`
+// 항목: notificationId, title, type, deeplink,
+// sentAt 또는 sent_at(ISO 8601·필수), isRead 또는 is_read(bool|0|1)
 
 /// 서버 `type` 문자열과 매핑되는 알림 유형
 enum NotificationType {
@@ -27,6 +31,21 @@ enum NotificationType {
     }
     return null;
   }
+
+  /// `deeplink`가 없을 때(원본 삭제 등) 모달에 쓰는 안내 문구
+  String get missingDeeplinkBodyKo {
+    return switch (this) {
+      NotificationType.schedule =>
+        '해당 일정은 존재하지 않습니다.\n'
+            '일정이 삭제되었을 수 있습니다.',
+      NotificationType.feedbackReply =>
+        '해당 문의 답변 내역은 존재하지 않습니다.\n'
+            '삭제되었을 수 있습니다.',
+      NotificationType.notice =>
+        '해당 공지는 존재하지 않습니다.\n'
+            '삭제되었을 수 있습니다.',
+    };
+  }
 }
 
 /// 단일 알림 항목
@@ -37,6 +56,7 @@ class NotificationItemDto {
     required this.type,
     required this.deeplink,
     required this.isRead,
+    required this.sentAt,
   });
 
   final int notificationId;
@@ -45,11 +65,80 @@ class NotificationItemDto {
   final String deeplink;
   final bool isRead;
 
+  /// 발송 시각 (로컬). API `sentAt`(ISO 8601) — 알림마다 반드시 있음
+  final DateTime sentAt;
+
+  static DateTime? _parseSentAt(dynamic v) {
+    if (v == null) return null;
+    if (v is String) {
+      final s = v.trim();
+      if (s.isEmpty) return null;
+      var parsed = DateTime.tryParse(s);
+      if (parsed != null) return parsed.toLocal();
+      // "yyyy-MM-dd HH:mm:ss" 등 공백 구분
+      if (s.contains(' ') && !s.contains('T')) {
+        parsed = DateTime.tryParse(s.replaceFirst(' ', 'T'));
+        if (parsed != null) return parsed.toLocal();
+      }
+      return null;
+    }
+    if (v is int && v > 2000000000000) {
+      return DateTime.fromMillisecondsSinceEpoch(v, isUtc: true).toLocal();
+    }
+    return null;
+  }
+
+  static bool _parseIsRead(dynamic v) {
+    if (v == null) return true;
+    if (v is bool) return v;
+    if (v is num) return v != 0;
+    if (v is String) {
+      final lower = v.toLowerCase();
+      return lower != 'false' && lower != '0';
+    }
+    return true;
+  }
+
+  NotificationItemDto copyWith({
+    int? notificationId,
+    String? title,
+    NotificationType? type,
+    String? deeplink,
+    bool? isRead,
+    DateTime? sentAt,
+  }) {
+    return NotificationItemDto(
+      notificationId: notificationId ?? this.notificationId,
+      title: title ?? this.title,
+      type: type ?? this.type,
+      deeplink: deeplink ?? this.deeplink,
+      isRead: isRead ?? this.isRead,
+      sentAt: sentAt ?? this.sentAt,
+    );
+  }
+
+  /// 목록 부제: 오늘 발송이면 `오늘`, 아니면 `yyyy.MM.dd`
+  String get listSubtitleKo {
+    final local = sentAt.toLocal();
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final day = DateTime(local.year, local.month, local.day);
+    if (day == today) return '오늘';
+    final y = local.year;
+    final m = local.month.toString().padLeft(2, '0');
+    final d = local.day.toString().padLeft(2, '0');
+    return '$y.$m.$d';
+  }
+
   factory NotificationItemDto.fromJson(Map<String, dynamic> json) {
     final typeRaw = json['type'] as String?;
     final type = NotificationType.tryParseApi(typeRaw);
     if (type == null) {
       throw FormatException('Unknown notification type: $typeRaw');
+    }
+    final parsedSentAt = _parseSentAt(json['sentAt'] ?? json['sent_at']);
+    if (parsedSentAt == null) {
+      throw FormatException('Missing or invalid sentAt');
     }
     final id = json['notificationId'];
     final notificationId = id is int
@@ -60,7 +149,8 @@ class NotificationItemDto {
       title: (json['title'] as String?)?.trim() ?? '',
       type: type,
       deeplink: (json['deeplink'] as String?)?.trim() ?? '',
-      isRead: json['isRead'] as bool? ?? true,
+      isRead: _parseIsRead(json['isRead'] ?? json['is_read']),
+      sentAt: parsedSentAt,
     );
   }
 }
@@ -71,16 +161,41 @@ class NotificationsPageResponseDto {
 
   final List<NotificationItemDto> notifications;
 
+  NotificationsPageResponseDto copyWith({
+    List<NotificationItemDto>? notifications,
+  }) {
+    return NotificationsPageResponseDto(
+      notifications: notifications ?? this.notifications,
+    );
+  }
+
+  /// 최상단 또는 `data` 안의 `notifications` 배열을 사용
+  static Map<String, dynamic> _notificationsRoot(Map<String, dynamic> json) {
+    if (json.containsKey('notifications')) return json;
+    final data = json['data'];
+    if (data is Map<String, dynamic>) return data;
+    if (data is Map) return Map<String, dynamic>.from(data);
+    return json;
+  }
+
+  static Map<String, dynamic>? _elementAsMap(dynamic e) {
+    if (e is Map<String, dynamic>) return e;
+    if (e is Map) return Map<String, dynamic>.from(e);
+    return null;
+  }
+
   factory NotificationsPageResponseDto.fromJson(Map<String, dynamic> json) {
-    final raw = json['notifications'];
+    final root = _notificationsRoot(json);
+    final raw = root['notifications'];
     if (raw is! List<dynamic>) {
       return const NotificationsPageResponseDto(notifications: []);
     }
     final items = <NotificationItemDto>[];
     for (final e in raw) {
-      if (e is! Map<String, dynamic>) continue;
+      final row = _elementAsMap(e);
+      if (row == null) continue;
       try {
-        items.add(NotificationItemDto.fromJson(e));
+        items.add(NotificationItemDto.fromJson(row));
       } on FormatException {
         continue;
       }

--- a/lib/views/screens/notification_screen.dart
+++ b/lib/views/screens/notification_screen.dart
@@ -3,30 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../controllers/auth_controller.dart';
-import '../../core/constants/api_constants.dart';
+import '../../controllers/notifications_page_controller.dart';
 import '../../core/constants/app_assets.dart';
 import '../../core/constants/app_colors.dart';
-import '../../core/deep_link/toit_deep_link_opener.dart';
-import '../../core/network/api_client.dart';
-import '../../models/dto/notifications_page_response_dto.dart';
+import '../widgets/notification/notification_list.dart';
 import 'notification_settings_screen.dart';
-
-/// GET /page/notifications 결과 Provider (세션·사용자 전환 시 캐시 분리)
-final notificationsPageProvider =
-    FutureProvider.family<NotificationsPageResponseDto, (int, int)>((
-      ref,
-      key,
-    ) async {
-      final (_, refreshTick) = key;
-      if (refreshTick < 0) {
-        throw StateError('Invalid refresh tick: $refreshTick');
-      }
-      final apiClient = ref.read(apiClientProvider);
-      final response = await apiClient.get(ApiConstants.notificationsEndpoint);
-      return NotificationsPageResponseDto.fromJson(
-        response.data as Map<String, dynamic>,
-      );
-    });
 
 /// 알림 목록 화면
 class NotificationScreen extends ConsumerWidget {
@@ -63,7 +44,7 @@ class NotificationScreen extends ConsumerWidget {
             Expanded(
               child: pageAsync.when(
                 data: (page) =>
-                    _NotificationsBody(cacheKey: cacheKey, page: page),
+                    NotificationList(cacheKey: cacheKey, page: page),
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (error, _) => _ErrorView(
                   message: '알림을 불러오지 못했습니다.\n$error',
@@ -76,72 +57,6 @@ class NotificationScreen extends ConsumerWidget {
         ),
       ),
     );
-  }
-}
-
-class _NotificationsBody extends ConsumerWidget {
-  const _NotificationsBody({required this.cacheKey, required this.page});
-
-  final (int, int) cacheKey;
-  final NotificationsPageResponseDto page;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final unread = page.notifications
-        .where((e) => !e.isRead)
-        .toList(growable: false);
-    final read = page.notifications
-        .where((e) => e.isRead)
-        .toList(growable: false);
-
-    if (unread.isEmpty && read.isEmpty) {
-      return RefreshIndicator(
-        color: AppColors.blue500,
-        onRefresh: () => _onRefresh(ref),
-        child: ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          children: const [
-            SizedBox(height: 120),
-            Center(
-              child: Text(
-                '알림이 없습니다.',
-                style: TextStyle(
-                  color: AppColors.gray600,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    return RefreshIndicator(
-      color: AppColors.blue500,
-      onRefresh: () => _onRefresh(ref),
-      child: ListView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        padding: EdgeInsets.zero,
-        children: [
-          if (unread.isNotEmpty) ...[
-            const _SectionLabel(title: '새로운 알림'),
-            _NotificationSection(items: unread),
-          ],
-          if (unread.isNotEmpty && read.isNotEmpty) const _SectionDivider(),
-          if (read.isNotEmpty) ...[
-            const _SectionLabel(title: '지난 알림'),
-            _NotificationSection(items: read),
-          ],
-          const SizedBox(height: 24),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _onRefresh(WidgetRef ref) async {
-    ref.invalidate(notificationsPageProvider(cacheKey));
-    await ref.read(notificationsPageProvider(cacheKey).future);
   }
 }
 
@@ -184,185 +99,6 @@ class _NotificationHeader extends StatelessWidget {
           ),
           const SizedBox(width: 8),
         ],
-      ),
-    );
-  }
-}
-
-class _SectionLabel extends StatelessWidget {
-  const _SectionLabel({required this.title});
-
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      color: AppColors.neutral300,
-      padding: const EdgeInsets.fromLTRB(20, 10, 20, 10),
-      child: Text(
-        title,
-        style: const TextStyle(
-          color: AppColors.gray600,
-          fontSize: 16,
-          fontWeight: FontWeight.w500,
-          height: 1.5,
-        ),
-      ),
-    );
-  }
-}
-
-class _NotificationSection extends ConsumerWidget {
-  const _NotificationSection({required this.items});
-
-  final List<NotificationItemDto> items;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final lastIndex = items.length - 1;
-    return Column(
-      children: items.asMap().entries.map((entry) {
-        return _NotificationCard(
-          item: entry.value,
-          showBottomDivider: entry.key != lastIndex,
-          onOpenDeeplink: () => _openItem(context, ref, entry.value),
-        );
-      }).toList(),
-    );
-  }
-
-  Future<void> _openItem(
-    BuildContext context,
-    WidgetRef ref,
-    NotificationItemDto item,
-  ) async {
-    final link = item.deeplink.trim();
-    if (link.isEmpty) {
-      if (context.mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(const SnackBar(content: Text('이동할 링크가 없습니다.')));
-      }
-      return;
-    }
-    await ToitDeepLinkOpener.open(ref, context, link);
-  }
-}
-
-class _SectionDivider extends StatelessWidget {
-  const _SectionDivider();
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 12),
-      child: Container(height: 10, color: AppColors.neutral300),
-    );
-  }
-}
-
-class _NotificationCard extends StatelessWidget {
-  const _NotificationCard({
-    required this.item,
-    required this.showBottomDivider,
-    required this.onOpenDeeplink,
-  });
-
-  final NotificationItemDto item;
-  final bool showBottomDivider;
-  final VoidCallback onOpenDeeplink;
-
-  @override
-  Widget build(BuildContext context) {
-    final rowBg = item.isRead
-        ? Colors.white
-        : AppColors.gradientLightBlue.withValues(alpha: 0.45);
-
-    return Material(
-      color: rowBg,
-      child: InkWell(
-        onTap: onOpenDeeplink,
-        child: Container(
-          padding: EdgeInsets.only(
-            left: 20,
-            right: 20,
-            top: 16,
-            bottom: showBottomDivider ? 16 : 0,
-          ),
-          decoration: BoxDecoration(
-            border: showBottomDivider
-                ? const Border(bottom: BorderSide(color: AppColors.neutral50))
-                : null,
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _NotificationTypeIcon(type: item.type),
-              const SizedBox(width: 13),
-              Expanded(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      item.title.isEmpty ? '(제목 없음)' : item.title,
-                      style: const TextStyle(
-                        color: AppColors.gray900,
-                        fontSize: 18,
-                        fontWeight: FontWeight.w600,
-                        height: 1.25,
-                      ),
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      item.type.labelKo,
-                      style: const TextStyle(
-                        color: AppColors.gray600,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
-                        height: 1.5,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _NotificationTypeIcon extends StatelessWidget {
-  const _NotificationTypeIcon({required this.type});
-
-  final NotificationType type;
-
-  @override
-  Widget build(BuildContext context) {
-    final path = switch (type) {
-      NotificationType.schedule => AppAssets.searchResultEventIcon,
-      NotificationType.feedbackReply => AppAssets.notificationFeedbackIcon,
-      NotificationType.notice => AppAssets.notificationNoticeIcon,
-    };
-
-    return Container(
-      width: 44,
-      height: 44,
-      decoration: BoxDecoration(
-        border: Border.all(color: AppColors.neutral50),
-        borderRadius: BorderRadius.circular(8),
-        color: Colors.white,
-      ),
-      child: Center(
-        child: SvgPicture.asset(
-          path,
-          width: 28,
-          height: 28,
-          fit: BoxFit.contain,
-        ),
       ),
     );
   }

--- a/lib/views/widgets/notification/notification_icon_box.dart
+++ b/lib/views/widgets/notification/notification_icon_box.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../../../core/constants/app_assets.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../models/dto/notifications_page_response_dto.dart';
+
+/// 알림 유형별 아이콘을 담는 둥근 사각형 박스 (피그마: 흰 배경·얇은 테두리)
+class NotificationIconBox extends StatelessWidget {
+  const NotificationIconBox({super.key, required this.type});
+
+  static const double _boxSize = 44;
+  static const double _iconSize = 24;
+  static const double _radius = 8;
+
+  final NotificationType type;
+
+  @override
+  Widget build(BuildContext context) {
+    final path = switch (type) {
+      NotificationType.schedule => AppAssets.searchResultEventIcon,
+      NotificationType.feedbackReply => AppAssets.notificationFeedbackIcon,
+      NotificationType.notice => AppAssets.notificationNoticeIcon,
+    };
+
+    return Container(
+      width: _boxSize,
+      height: _boxSize,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        border: Border.all(color: AppColors.borderLight),
+        borderRadius: BorderRadius.circular(_radius),
+      ),
+      child: Center(
+        child: SvgPicture.asset(
+          path,
+          width: _iconSize,
+          height: _iconSize,
+          fit: BoxFit.contain,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/notification/notification_list.dart
+++ b/lib/views/widgets/notification/notification_list.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../controllers/notifications_page_controller.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../core/deep_link/toit_deep_link_opener.dart';
+import '../../../models/dto/notifications_page_response_dto.dart';
+import '../common/app_alert_dialog.dart';
+import 'notification_list_item.dart';
+
+/// 알림 목록 본문 (섹션 + [NotificationListItem] 나열)
+class NotificationList extends ConsumerWidget {
+  const NotificationList({
+    super.key,
+    required this.cacheKey,
+    required this.page,
+  });
+
+  final (int, int) cacheKey;
+  final NotificationsPageResponseDto page;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final unread = page.notifications
+        .where((e) => !e.isRead)
+        .toList(growable: false);
+    final read = page.notifications
+        .where((e) => e.isRead)
+        .toList(growable: false);
+
+    if (unread.isEmpty && read.isEmpty) {
+      return RefreshIndicator(
+        color: AppColors.blue500,
+        onRefresh: () => _onRefresh(ref),
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 120),
+            Center(
+              child: Text(
+                '알림이 없습니다.',
+                style: TextStyle(
+                  color: AppColors.gray600,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      color: AppColors.blue500,
+      onRefresh: () => _onRefresh(ref),
+      child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: EdgeInsets.zero,
+        children: [
+          if (unread.isNotEmpty) ...[
+            const _SectionLabel(title: '새로운 알림'),
+            _NotificationSection(cacheKey: cacheKey, items: unread),
+          ],
+          if (unread.isNotEmpty && read.isNotEmpty) const _SectionDivider(),
+          if (read.isNotEmpty) ...[
+            const _SectionLabel(title: '지난 알림'),
+            _NotificationSection(cacheKey: cacheKey, items: read),
+          ],
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _onRefresh(WidgetRef ref) async {
+    await ref.read(notificationsPageProvider(cacheKey).notifier).refresh();
+  }
+}
+
+/// 피그마: 회색 띠 없이 좌측 정렬 텍스트만
+class _SectionLabel extends StatelessWidget {
+  const _SectionLabel({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 14, 20, 8),
+      child: Text(
+        title,
+        style: const TextStyle(
+          color: AppColors.gray600,
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          height: 1.35,
+        ),
+      ),
+    );
+  }
+}
+
+/// 새로운 알림 / 지난 알림 사이 구분 (가로 전체, 높이 10)
+class _SectionDivider extends StatelessWidget {
+  const _SectionDivider();
+
+  static const double _height = 10;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 12),
+      child: SizedBox(
+        width: double.infinity,
+        height: _height,
+        child: const DecoratedBox(
+          decoration: BoxDecoration(
+            color: AppColors.neutral300,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationSection extends ConsumerWidget {
+  const _NotificationSection({required this.cacheKey, required this.items});
+
+  final (int, int) cacheKey;
+  final List<NotificationItemDto> items;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final lastIndex = items.length - 1;
+    return Column(
+      children: items.asMap().entries.map((entry) {
+        return NotificationListItem(
+          item: entry.value,
+          showBottomDivider: entry.key != lastIndex,
+          onTap: () => _openItem(context, ref, cacheKey, entry.value),
+        );
+      }).toList(),
+    );
+  }
+
+  Future<void> _openItem(
+    BuildContext context,
+    WidgetRef ref,
+    (int, int) cacheKey,
+    NotificationItemDto item,
+  ) async {
+    ref
+        .read(notificationsPageProvider(cacheKey).notifier)
+        .scheduleMarkReadIfUnread(item.notificationId);
+
+    final link = item.deeplink.trim();
+    if (link.isEmpty) {
+      if (context.mounted) {
+        await showAppAlertDialog(
+          context,
+          message: item.type.missingDeeplinkBodyKo,
+        );
+      }
+      return;
+    }
+    await ToitDeepLinkOpener.open(ref, context, link);
+  }
+}

--- a/lib/views/widgets/notification/notification_list_item.dart
+++ b/lib/views/widgets/notification/notification_list_item.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/constants/app_colors.dart';
+import '../../../models/dto/notifications_page_response_dto.dart';
+import '../common/app_divider.dart';
+import 'notification_icon_box.dart';
+
+/// 알림 목록 한 행 (아이콘 + 제목 + sentAt 부제)
+class NotificationListItem extends StatelessWidget {
+  const NotificationListItem({
+    super.key,
+    required this.item,
+    required this.showBottomDivider,
+    required this.onTap,
+  });
+
+  final NotificationItemDto item;
+  final bool showBottomDivider;
+  final VoidCallback onTap;
+
+  static const double _horizontalPad = 20;
+  static const double _verticalPad = 14;
+  static const double _gapIconText = 13;
+  static const double _gapTitleSentAt = 4;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.white,
+      child: InkWell(
+        onTap: onTap,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                _horizontalPad,
+                _verticalPad,
+                _horizontalPad,
+                _verticalPad,
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  NotificationIconBox(type: item.type),
+                  const SizedBox(width: _gapIconText),
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          item.title.isEmpty ? '(제목 없음)' : item.title,
+                          softWrap: true,
+                          style: const TextStyle(
+                            color: AppColors.gray900,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w700,
+                            height: 1.35,
+                          ),
+                        ),
+                        const SizedBox(height: _gapTitleSentAt),
+                        Text(
+                          item.listSubtitleKo,
+                          style: const TextStyle(
+                            color: AppColors.gray600,
+                            fontSize: 13,
+                            fontWeight: FontWeight.w500,
+                            height: 1.35,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (showBottomDivider) const AppDivider(indent: 0, endIndent: 0),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/models/notifications_page_response_dto_test.dart
+++ b/test/models/notifications_page_response_dto_test.dart
@@ -3,7 +3,7 @@ import 'package:poj_todo/models/dto/notifications_page_response_dto.dart';
 
 void main() {
   group('NotificationsPageResponseDto', () {
-    test('notifications 배열을 파싱하고 알 수 없는 type은 건너뛴다', () {
+    test('notifications 배열에서 유효 항목만 순서대로 파싱한다', () {
       final dto = NotificationsPageResponseDto.fromJson(<String, dynamic>{
         'notifications': <dynamic>[
           <String, dynamic>{
@@ -11,20 +11,15 @@ void main() {
             'title': '일정 알림',
             'type': 'SCHEDULE',
             'deeplink': 'toit://schedule?id=9',
+            'sentAt': '2026-04-24T11:47:10.991Z',
             'isRead': false,
-          },
-          <String, dynamic>{
-            'notificationId': 2,
-            'title': '무시',
-            'type': 'UNKNOWN',
-            'deeplink': '',
-            'isRead': true,
           },
           <String, dynamic>{
             'notificationId': 3,
             'title': '공지',
             'type': 'NOTICE',
             'deeplink': 'https://example.com/n',
+            'sentAt': '2026-01-02T00:00:00.000Z',
             'isRead': true,
           },
         ],
@@ -33,12 +28,99 @@ void main() {
       expect(dto.notifications.length, 2);
       expect(dto.notifications[0].type, NotificationType.schedule);
       expect(dto.notifications[0].isRead, isFalse);
+      expect(dto.notifications[0].sentAt.toUtc().year, 2026);
       expect(dto.notifications[1].type, NotificationType.notice);
+    });
+
+    test('알 수 없는 type 한 건은 건너뛰고 나머지는 유지한다', () {
+      final dto = NotificationsPageResponseDto.fromJson(<String, dynamic>{
+        'notifications': <dynamic>[
+          <String, dynamic>{
+            'notificationId': 1,
+            'title': 'a',
+            'type': 'SCHEDULE',
+            'deeplink': '',
+            'sentAt': '2026-04-24T10:00:00.000Z',
+            'isRead': true,
+          },
+          <String, dynamic>{
+            'notificationId': 99,
+            'title': 'b',
+            'type': 'UNKNOWN',
+            'deeplink': '',
+            'sentAt': '2026-04-24T11:00:00.000Z',
+            'isRead': true,
+          },
+          <String, dynamic>{
+            'notificationId': 3,
+            'title': 'c',
+            'type': 'NOTICE',
+            'deeplink': '',
+            'sentAt': '2026-04-24T12:00:00.000Z',
+            'isRead': false,
+          },
+        ],
+      });
+      expect(dto.notifications.length, 2);
+      expect(dto.notifications[0].notificationId, 1);
+      expect(dto.notifications[1].notificationId, 3);
+    });
+
+    test('sentAt 없으면 fromJson이 FormatException', () {
+      expect(
+        () => NotificationItemDto.fromJson(<String, dynamic>{
+          'notificationId': 0,
+          'title': 't',
+          'type': 'NOTICE',
+          'deeplink': '',
+          'isRead': true,
+        }),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('sentAt 없는 항목은 페이지 파싱 시 건너뜀', () {
+      final dto = NotificationsPageResponseDto.fromJson(<String, dynamic>{
+        'notifications': <dynamic>[
+          <String, dynamic>{
+            'notificationId': 1,
+            'title': '유효',
+            'type': 'SCHEDULE',
+            'deeplink': '',
+            'sentAt': '2026-04-24T12:00:00.000Z',
+            'isRead': true,
+          },
+          <String, dynamic>{
+            'notificationId': 2,
+            'title': '무효',
+            'type': 'SCHEDULE',
+            'deeplink': '',
+            'isRead': true,
+          },
+        ],
+      });
+      expect(dto.notifications.length, 1);
+      expect(dto.notifications[0].notificationId, 1);
     });
 
     test('notifications 키가 없으면 빈 목록', () {
       final dto = NotificationsPageResponseDto.fromJson(<String, dynamic>{});
       expect(dto.notifications, isEmpty);
+    });
+
+    test('NotificationItemDto copyWith로 isRead만 변경', () {
+      final a = NotificationItemDto.fromJson(<String, dynamic>{
+        'notificationId': 1,
+        'title': 't',
+        'type': 'NOTICE',
+        'deeplink': '',
+        'sentAt': '2026-04-24T10:00:00.000Z',
+        'isRead': false,
+      });
+      final b = a.copyWith(isRead: true);
+      expect(a.isRead, isFalse);
+      expect(b.isRead, isTrue);
+      expect(b.title, a.title);
     });
   });
 
@@ -48,6 +130,18 @@ void main() {
         NotificationType.tryParseApi('FEEDBACK_REPLY'),
         NotificationType.feedbackReply,
       );
+    });
+
+    test('missingDeeplinkBodyKo는 유형별 존재하지 않음 안내', () {
+      expect(NotificationType.schedule.missingDeeplinkBodyKo, contains('일정'));
+      expect(
+        NotificationType.feedbackReply.missingDeeplinkBodyKo,
+        contains('문의'),
+      );
+      expect(NotificationType.notice.missingDeeplinkBodyKo, contains('공지'));
+      for (final t in NotificationType.values) {
+        expect(t.missingDeeplinkBodyKo, contains('존재하지 않습니다'));
+      }
     });
   });
 }


### PR DESCRIPTION
- 알림 목록 상태·GET 요청을 담당하는 NotificationsPageNotifier 추가
- NotificationsPageResponseDto·NotificationItemDto로 응답 구조 처리
- NotificationList·NotificationListItem으로 목록 UI 구성
- 탭 시 읽음 PATCH 및 딥링크·딥링크 없음 모달 처리
- 읽음 API 경로 ApiConstants 반영
- 알림 JSON 파싱·엣지 케이스 단위 테스트 추가

Made-with: Cursor