### PR TITLE
fix: 세션 만료 안내 다이얼로그 적용 및 인증 전환 UX 개선

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -171,27 +171,27 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
-  firebase_core: ee30637e6744af8e0c12a6a1e8a9718506ec2398
-  firebase_messaging: 343de01a8d3e18b60df0c6d37f7174c44ae38e02
+  firebase_core: 8d5e24676350f15dd111aa59a88a1ae26605f9ba
+  firebase_messaging: 834cfc0887393d3108cdb19da8e57655c54fd0e4
   FirebaseCore: 0dbad74bda10b8fb9ca34ad8f375fb9dd3ebef7c
   FirebaseCoreInternal: fe5fa466aeb314787093a7dce9f0beeaad5a2a21
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseMessaging: 7f42cfd10ec64181db4e01b305a613791c8e782c
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_web_auth_2: 4091f1645696258ddc57849f62bef2a848fc313c
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
+  receive_sharing_intent: 79c848f5b045674ad60b9fea3bafea59962ad2c1
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: 9e96353205564ae51eaf5422c660a3c602958b89
 

--- a/lib/core/utils/schedule_range_display_utils.dart
+++ b/lib/core/utils/schedule_range_display_utils.dart
@@ -1,4 +1,4 @@
-import 'package:poj_todo/models/calendar/calendar_event.dart';
+import '../../models/calendar/calendar_event.dart';
 
 /// 일정 기간·시간을 바텀시트 등에서 한 줄로 표시할 때 사용한다.
 class ScheduleRangeDisplayUtils {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ import 'views/screens/navigation_shell.dart'
     show NavigationShell, pendingDeepLinkUrlProvider;
 import 'views/screens/splash_retry_screen.dart';
 import 'views/screens/splash_screen.dart';
+import 'views/widgets/common/app_alert_dialog.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -58,6 +59,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
   static const _launchInfoChannel = MethodChannel(
     'com.example.pojTodo/launch_info',
   );
+  final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
   /// 스플래시가 최소한 이 시간만큼은 노출되도록 보장한다.
   /// 부트스트랩이 너무 빨라 화면이 깜빡이는 인상을 주지 않기 위함.
@@ -68,6 +70,8 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
   /// 스플래시 최소 노출 시간이 지난 뒤에만 true.
   /// `authState`가 먼저 확정되더라도 이 값이 false인 동안에는 스플래시를 유지한다.
   bool _isSplashFinished = false;
+  bool _showSessionExpiredNotice = false;
+  bool _isSessionExpiredDialogShowing = false;
 
   @override
   void initState() {
@@ -146,6 +150,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
     apiClient.enableAuth(
       authService: authService,
       onForceLogout: () {
+        _showSessionExpiredNotice = true;
         ref.read(authProvider.notifier).forceLogout();
       },
     );
@@ -193,6 +198,11 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AuthStatus>(
+      authProvider.select((state) => state.status),
+      _handleAuthStatusChanged,
+    );
+
     final bootstrapStatus = ref.watch(
       bootstrapProvider.select((state) => state.status),
     );
@@ -201,6 +211,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
     return MaterialApp(
       title: 'toIT',
       debugShowCheckedModeBanner: false,
+      navigatorKey: _rootNavigatorKey,
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       home: _buildHome(bootstrapStatus, authStatus),
@@ -269,5 +280,43 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
     if (_lastRouteLog == name) return;
     _lastRouteLog = name;
     debugPrint('[BOOT] route_decided home=$name');
+  }
+
+  void _handleAuthStatusChanged(AuthStatus? previous, AuthStatus next) {
+    if (next == AuthStatus.authenticated) {
+      _showSessionExpiredNotice = false;
+      return;
+    }
+    if (next != AuthStatus.unauthenticated || !_showSessionExpiredNotice) {
+      return;
+    }
+
+    if (_isSessionExpiredDialogShowing) return;
+    _showSessionExpiredNotice = false;
+    _isSessionExpiredDialogShowing = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) {
+        _isSessionExpiredDialogShowing = false;
+        return;
+      }
+
+      final navigator = _rootNavigatorKey.currentState;
+      final dialogContext = _rootNavigatorKey.currentContext;
+      if (navigator == null || dialogContext == null) {
+        _isSessionExpiredDialogShowing = false;
+        return;
+      }
+
+      await showAppAlertDialog(
+        dialogContext,
+        message: '세션이 만료되어 다시 로그인해 주세요.',
+        confirmLabel: '확인',
+      );
+
+      if (mounted) {
+        navigator.popUntil((route) => route.isFirst);
+      }
+      _isSessionExpiredDialogShowing = false;
+    });
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:


### PR DESCRIPTION
- 토큰 만료로 강제 로그아웃이 발생했을 때 스낵바 대신 공통 AppAlertDialog를 사용해 사용자 안내를 일관되게 제공
- 세션 만료 안내에서 확인 버튼을 누른 뒤 로그인 화면으로 이동하도록 흐름을 조정해 전환 시점을 명확하게 개선
- 강제 로그아웃 시 수동 라우트 push로 인한 로그인 후 화면 미전환 이슈를 해소하기 위해 네비게이션 스택 정리 방식으로 안정화
- 인증 상태 변화(unauthenticated)와 화면 전환 로직을 정리하여 상세 화면 진입 중에도 예측 가능한 로그아웃 동작을 보장
- 토큰 재발급/만료 테스트 시나리오(재발급 성공, 재발급 실패 로그아웃, 동시 401 single-flight) 검증 기준에 맞춰 UX 동작을 보완