### PR TITLE
feat: 알림 수신 및 읽지 않은 알림 수 카운터 기능 추가

### DIFF
--- a/lib/controllers/notifications_page_controller.dart
+++ b/lib/controllers/notifications_page_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../core/constants/api_constants.dart';
 import '../core/network/api_client.dart';
 import '../models/dto/notifications_page_response_dto.dart';
+import 'notifications_unread_count_controller.dart';
 
 Future<NotificationsPageResponseDto> _fetchNotificationsPage(Ref ref) async {
   final apiClient = ref.read(apiClientProvider);
@@ -77,6 +78,9 @@ class NotificationsPageNotifier
       ],
     );
     state = AsyncValue.data(updated);
+    _ref
+        .read(notificationsUnreadCountProvider(_cacheKey).notifier)
+        .consumeOneUnreadOptimistic();
 
     Future(() async {
       try {
@@ -86,6 +90,9 @@ class NotificationsPageNotifier
       } catch (_) {
         try {
           state = AsyncValue.data(previous);
+          _ref
+              .read(notificationsUnreadCountProvider(_cacheKey).notifier)
+              .restoreOneUnreadOnFailure();
         } on Object {
           // Provider 해제 직후 등 상태 반영 불가 시 무시
         }

--- a/lib/controllers/notifications_unread_count_controller.dart
+++ b/lib/controllers/notifications_unread_count_controller.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/constants/api_constants.dart';
+import '../core/network/api_client.dart';
+import '../models/dto/notifications_unread_count_response_dto.dart';
+
+Future<NotificationsUnreadCountResponseDto> _fetchUnreadCount(Ref ref) async {
+  final apiClient = ref.read(apiClientProvider);
+  final response = await apiClient.get(
+    ApiConstants.notificationsUnreadCountEndpoint,
+  );
+  final body = response.data;
+  final Map<String, dynamic> jsonMap;
+  if (body is Map<String, dynamic>) {
+    jsonMap = body;
+  } else if (body is Map) {
+    jsonMap = Map<String, dynamic>.from(body);
+  } else {
+    throw StateError(
+      'Unexpected /api/notifications/unread-count body: '
+      '${body.runtimeType}',
+    );
+  }
+  return NotificationsUnreadCountResponseDto.fromJson(jsonMap);
+}
+
+class NotificationsUnreadCountNotifier extends StateNotifier<AsyncValue<int>> {
+  NotificationsUnreadCountNotifier(this._ref, this._cacheKey)
+    : super(const AsyncValue.loading()) {
+    _load();
+  }
+
+  final Ref _ref;
+  final (int, int) _cacheKey;
+
+  Future<void> _load() async {
+    final (_, refreshTick) = _cacheKey;
+    if (refreshTick < 0) {
+      state = AsyncValue.error(
+        StateError('Invalid refresh tick: $refreshTick'),
+        StackTrace.current,
+      );
+      return;
+    }
+    state = await AsyncValue.guard(() async {
+      final dto = await _fetchUnreadCount(_ref);
+      return dto.unreadCount;
+    });
+  }
+
+  Future<void> refresh() async {
+    await _load();
+  }
+
+  void consumeOneUnreadOptimistic() {
+    final value = state.value;
+    if (value == null) return;
+    state = AsyncValue.data(value > 0 ? value - 1 : 0);
+  }
+
+  void restoreOneUnreadOnFailure() {
+    final value = state.value;
+    if (value == null) return;
+    state = AsyncValue.data(value + 1);
+  }
+}
+
+final notificationsUnreadCountProvider =
+    StateNotifierProvider.family<
+      NotificationsUnreadCountNotifier,
+      AsyncValue<int>,
+      (int, int)
+    >((ref, key) {
+      return NotificationsUnreadCountNotifier(ref, key);
+    });

--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -41,6 +41,10 @@ class ApiConstants {
   static String notificationReadPath(int notificationId) =>
       '/api/notifications/$notificationId/read';
 
+  /// 미읽음 알림 개수 (GET /api/notifications/unread-count)
+  static const String notificationsUnreadCountEndpoint =
+      '/api/notifications/unread-count';
+
   /// 자료 링크 추가 (POST)
   static const String linksEndpoint = '/links';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 
 import 'controllers/auth_controller.dart';
 import 'controllers/bootstrap_controller.dart';
+import 'controllers/notifications_unread_count_controller.dart';
 import 'core/deep_link/toit_deep_link.dart';
 import 'core/network/api_client.dart';
 import 'core/theme/app_theme.dart';
@@ -66,6 +67,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
   static const _minSplashDuration = Duration(milliseconds: 1500);
 
   StreamSubscription<String>? _fcmTokenRefreshSub;
+  StreamSubscription<RemoteMessage>? _fcmOnMessageSub;
 
   /// 스플래시 최소 노출 시간이 지난 뒤에만 true.
   /// `authState`가 먼저 확정되더라도 이 값이 false인 동안에는 스플래시를 유지한다.
@@ -85,12 +87,14 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
     });
     _bindFcmDeepLinks();
     _bindFcmTokenRefresh();
+    _bindFcmUnreadCountRefresh();
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _fcmTokenRefreshSub?.cancel();
+    _fcmOnMessageSub?.cancel();
     super.dispose();
   }
 
@@ -135,9 +139,33 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
   }
 
   void _onFcmMessageOpened(RemoteMessage message) {
+    _refreshUnreadCountIfAuthenticated();
     final url = ToitDeepLink.extractUrlFromFcmData(message.data);
     if (url == null) return;
     ref.read(pendingDeepLinkUrlProvider.notifier).state = url;
+  }
+
+  /// 포그라운드 알림 수신 시 unread 배지를 갱신한다.
+  void _bindFcmUnreadCountRefresh() {
+    _fcmOnMessageSub = FirebaseMessaging.onMessage.listen((_) {
+      _refreshUnreadCountIfAuthenticated();
+    });
+  }
+
+  void _refreshUnreadCountIfAuthenticated() {
+    final authState = ref.read(authProvider);
+    final userId = authState.userId;
+    if (authState.status != AuthStatus.authenticated || userId == null) {
+      return;
+    }
+    final refreshTick = ref.read(authSessionRefreshTickProvider);
+    unawaited(
+      ref
+          .read(
+            notificationsUnreadCountProvider((userId, refreshTick)).notifier,
+          )
+          .refresh(),
+    );
   }
 
   Future<void> _initAuth() async {

--- a/lib/models/dto/notifications_unread_count_response_dto.dart
+++ b/lib/models/dto/notifications_unread_count_response_dto.dart
@@ -1,0 +1,35 @@
+/// GET /api/notifications/unread-count 응답 DTO
+class NotificationsUnreadCountResponseDto {
+  const NotificationsUnreadCountResponseDto({required this.unreadCount});
+
+  final int unreadCount;
+
+  factory NotificationsUnreadCountResponseDto.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    final root = _extractRoot(json);
+    final rawCount = root['unreadCount'];
+    final parsedCount = switch (rawCount) {
+      int value => value,
+      String value => int.tryParse(value.trim()) ?? 0,
+      _ => 0,
+    };
+    return NotificationsUnreadCountResponseDto(
+      unreadCount: parsedCount < 0 ? 0 : parsedCount,
+    );
+  }
+
+  static Map<String, dynamic> _extractRoot(Map<String, dynamic> json) {
+    if (json.containsKey('unreadCount')) {
+      return json;
+    }
+    final data = json['data'];
+    if (data is Map<String, dynamic>) {
+      return data;
+    }
+    if (data is Map) {
+      return Map<String, dynamic>.from(data);
+    }
+    return json;
+  }
+}

--- a/lib/views/screens/calendar_screen.dart
+++ b/lib/views/screens/calendar_screen.dart
@@ -21,17 +21,13 @@ class CalendarScreen extends ConsumerWidget {
         child: HomeAppBar(
           title: '캘린더',
           onMenuPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => const MyScreen(),
-              ),
-            );
+            Navigator.of(
+              context,
+            ).push(MaterialPageRoute<void>(builder: (_) => const MyScreen()));
           },
           onSearchPressed: () {
             Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => const SearchScreen(),
-              ),
+              MaterialPageRoute<void>(builder: (_) => const SearchScreen()),
             );
           },
           onNotificationPressed: () {

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -35,9 +35,7 @@ class HomeScreen extends ConsumerWidget {
             },
             onSearchPressed: () {
               Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => const SearchScreen(),
-                ),
+                MaterialPageRoute<void>(builder: (_) => const SearchScreen()),
               );
             },
             onNotificationPressed: () {

--- a/lib/views/screens/my_screen.dart
+++ b/lib/views/screens/my_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../controllers/auth_controller.dart';
+import '../../controllers/notifications_unread_count_controller.dart';
 import '../../core/constants/api_constants.dart';
 import '../../core/constants/app_assets.dart';
 import '../../core/constants/app_colors.dart';
@@ -89,6 +90,27 @@ class MyScreen extends ConsumerWidget {
                       ref.invalidate(myPageProvider(cacheKey));
                     }
                   },
+                  onSupportPressed: () async {
+                    final result = await Navigator.of(context).push<String>(
+                      MaterialPageRoute<String>(
+                        builder: (_) => const SupportScreen(),
+                      ),
+                    );
+                    await ref
+                        .read(
+                          notificationsUnreadCountProvider((
+                            userId,
+                            refreshTick,
+                          )).notifier,
+                        )
+                        .refresh();
+                    if (!context.mounted) return;
+                    if (result != null && result.isNotEmpty) {
+                      ScaffoldMessenger.of(
+                        context,
+                      ).showSnackBar(SnackBar(content: Text(result)));
+                    }
+                  },
                 ),
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (error, _) => _ErrorView(
@@ -154,11 +176,13 @@ class _MyContent extends StatelessWidget {
     required this.myPage,
     required this.storageUsageAsync,
     required this.onEditProfilePressed,
+    required this.onSupportPressed,
   });
 
   final MyPageResponseDto myPage;
   final AsyncValue<StorageUsageResponseDto> storageUsageAsync;
   final VoidCallback onEditProfilePressed;
+  final Future<void> Function() onSupportPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -246,19 +270,7 @@ class _MyContent extends StatelessWidget {
                   subtitle: '고객센터, 의견, 공지사항',
                   showChevron: true,
                   scale: scale,
-                  onTap: () async {
-                    final result = await Navigator.of(context).push<String>(
-                      MaterialPageRoute<String>(
-                        builder: (_) => const SupportScreen(),
-                      ),
-                    );
-                    if (!context.mounted) return;
-                    if (result != null && result.isNotEmpty) {
-                      ScaffoldMessenger.of(
-                        context,
-                      ).showSnackBar(SnackBar(content: Text(result)));
-                    }
-                  },
+                  onTap: onSupportPressed,
                 ),
                 Container(height: s(10), color: AppColors.neutral300),
                 _SettingTile(

--- a/lib/views/widgets/home/home_app_bar.dart
+++ b/lib/views/widgets/home/home_app_bar.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../controllers/auth_controller.dart';
+import '../../../controllers/notifications_unread_count_controller.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_spacing.dart';
 import '../../../core/constants/app_assets.dart';
 
 /// 홈/캘린더 등 공통 상단 앱바
-class HomeAppBar extends StatelessWidget {
+class HomeAppBar extends ConsumerWidget {
   const HomeAppBar({
     super.key,
     this.title = '마이',
@@ -17,6 +20,7 @@ class HomeAppBar extends StatelessWidget {
   });
 
   final String title;
+
   /// `true`면 희미한 아이콘(흰색) — 그라데이션/어두운 상단 배경용(홈).
   /// `false`면 어두운 아이콘 — 밝은 배경용(캘린더).
   final bool useLightStatusBar;
@@ -25,7 +29,15 @@ class HomeAppBar extends StatelessWidget {
   final VoidCallback? onNotificationPressed;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final userId = ref.watch(authProvider.select((state) => state.userId));
+    final refreshTick = ref.watch(authSessionRefreshTickProvider);
+    final unreadCountAsync = userId == null
+        ? const AsyncValue<int>.data(0)
+        : ref.watch(notificationsUnreadCountProvider((userId, refreshTick)));
+    final unreadCount = unreadCountAsync.valueOrNull ?? 0;
+    final hasUnread = unreadCount > 0;
+    final badgeText = unreadCount > 99 ? '99+' : '$unreadCount';
     final systemOverlay = useLightStatusBar
         ? SystemUiOverlayStyle.light.copyWith(
             statusBarColor: Colors.transparent,
@@ -72,18 +84,35 @@ class HomeAppBar extends StatelessWidget {
                 ),
                 onPressed: onNotificationPressed,
               ),
-              Positioned(
-                right: 10,
-                top: 10,
-                child: Container(
-                  width: 10,
-                  height: 10,
-                  decoration: const BoxDecoration(
-                    color: AppColors.badge,
-                    shape: BoxShape.circle,
+              if (hasUnread)
+                Positioned(
+                  right: 4,
+                  top: 6,
+                  child: Container(
+                    constraints: const BoxConstraints(
+                      minWidth: 16,
+                      minHeight: 16,
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColors.badge,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    alignment: Alignment.center,
+                    child: Text(
+                      badgeText,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                        height: 1.1,
+                      ),
+                    ),
                   ),
                 ),
-              ),
             ],
           ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:

--- a/test/core/constants/api_constants_notifications_unread_count_test.dart
+++ b/test/core/constants/api_constants_notifications_unread_count_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poj_todo/core/constants/api_constants.dart';
+
+void main() {
+  test('notificationsUnreadCountEndpoint is unread count path', () {
+    expect(
+      ApiConstants.notificationsUnreadCountEndpoint,
+      '/api/notifications/unread-count',
+    );
+  });
+}

--- a/test/models/notifications_unread_count_response_dto_test.dart
+++ b/test/models/notifications_unread_count_response_dto_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:poj_todo/models/dto/notifications_unread_count_response_dto.dart';
+
+void main() {
+  group('NotificationsUnreadCountResponseDto', () {
+    test('최상위 unreadCount를 파싱한다', () {
+      final dto = NotificationsUnreadCountResponseDto.fromJson(
+        <String, dynamic>{'unreadCount': 7},
+      );
+      expect(dto.unreadCount, 7);
+    });
+
+    test('data 내부 unreadCount 문자열도 파싱한다', () {
+      final dto = NotificationsUnreadCountResponseDto.fromJson(
+        <String, dynamic>{
+          'data': <String, dynamic>{'unreadCount': '12'},
+        },
+      );
+      expect(dto.unreadCount, 12);
+    });
+
+    test('음수 unreadCount는 0으로 보정한다', () {
+      final dto = NotificationsUnreadCountResponseDto.fromJson(
+        <String, dynamic>{'unreadCount': -4},
+      );
+      expect(dto.unreadCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
- Firebase Cloud Messaging을 통해 포그라운드에서 알림 수신 시 읽지 않은 알림 카운트를 갱신하는 기능 구현
- 새로운 notifications_unread_count_controller 추가 및 관련 DTO 모델 생성
- API 상수에 읽지 않은 알림 카운트 엔드포인트 추가
- UI에서 읽지 않은 알림 수를 표시하도록 HomeAppBar 및 MyScreen 업데이트
- 관련 테스트 케이스 추가