### PR TITLE
feat: 알림 텍스트 변환 로직 개선

### DIFF
--- a/lib/controllers/event_form_controller.dart
+++ b/lib/controllers/event_form_controller.dart
@@ -91,7 +91,9 @@ class EventFormState with _$EventFormState {
   /// 알림 텍스트 변환
   String? get alarmText {
     if (alarmMinutes == null) return null;
-    if (alarmMinutes == 0) return '일정 시작';
+    if (alarmMinutes == 0) {
+      return timeSetting ? '일정 시작' : '이벤트 당일(09:00)';
+    }
     if (alarmMinutes == 10080) return '1주 전';
     if (alarmMinutes! < 60) return '$alarmMinutes분 전';
     if (alarmMinutes! < 1440) return '${alarmMinutes! ~/ 60}시간 전';

--- a/lib/views/screens/event_detail_screen.dart
+++ b/lib/views/screens/event_detail_screen.dart
@@ -28,8 +28,8 @@ import '../widgets/event/color_context_menu.dart';
 import 'folder_detail_screen.dart';
 
 /// 알림 분 단위를 표시 텍스트로 변환
-String _alarmOffsetToText(int minutes) {
-  if (minutes == 0) return '일정 시작';
+String _alarmOffsetToText({required int minutes, required bool timeSetting}) {
+  if (minutes == 0) return timeSetting ? '일정 시작' : '이벤트 당일(09:00)';
   if (minutes == 10080) return '1주 전';
   if (minutes < 60) return '$minutes분 전';
   if (minutes < 1440) return '${minutes ~/ 60}시간 전';
@@ -340,7 +340,10 @@ class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
 
   List<EventSectionItem> _buildSections(ScheduleDetailResponse detail) {
     final alarmText = detail.alarmState
-        ? _alarmOffsetToText(detail.alarmOffsetMinutes)
+        ? _alarmOffsetToText(
+            minutes: detail.alarmOffsetMinutes,
+            timeSetting: detail.timeSetting,
+          )
         : null;
 
     return [


### PR DESCRIPTION
- 이벤트 폼 및 상세 화면에서 알림 텍스트를 설정하는 로직을 수정하여, 알림 분이 0일 때 '일정 시작' 또는 '이벤트 당일(09:00)'으로 표시하도록 개선
- 알림 텍스트 변환 함수에 timeSetting 매개변수를 추가하여 유연한 텍스트 출력을 지원