### PR TITLE
fix: 중복 메서드 선언 및 미정의 타입 참조 제거

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -66,11 +66,6 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
   - Flutter (1.0.0)
-  - flutter_image_compress_common (1.0.0):
-    - Flutter
-    - Mantle
-    - SDWebImage
-    - SDWebImageWebPCoder
   - flutter_secure_storage_darwin (10.0.0):
     - Flutter
     - FlutterMacOS
@@ -107,21 +102,6 @@ PODS:
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
-  - libwebp (1.5.0):
-    - libwebp/demux (= 1.5.0)
-    - libwebp/mux (= 1.5.0)
-    - libwebp/sharpyuv (= 1.5.0)
-    - libwebp/webp (= 1.5.0)
-  - libwebp/demux (1.5.0):
-    - libwebp/webp
-  - libwebp/mux (1.5.0):
-    - libwebp/demux
-  - libwebp/sharpyuv (1.5.0)
-  - libwebp/webp (1.5.0):
-    - libwebp/sharpyuv
-  - Mantle (2.2.0):
-    - Mantle/extobjc (= 2.2.0)
-  - Mantle/extobjc (2.2.0)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -135,9 +115,6 @@ PODS:
   - SDWebImage (5.21.7):
     - SDWebImage/Core (= 5.21.7)
   - SDWebImage/Core (5.21.7)
-  - SDWebImageWebPCoder (0.15.0):
-    - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.17)
   - share_plus (0.0.1):
     - Flutter
   - sqflite_darwin (0.0.4):
@@ -152,7 +129,6 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - Flutter (from `Flutter`)
-  - flutter_image_compress_common (from `.symlinks/plugins/flutter_image_compress_common/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
   - image_gallery_saver (from `.symlinks/plugins/image_gallery_saver/ios`)
@@ -174,12 +150,9 @@ SPEC REPOS:
     - FirebaseMessaging
     - GoogleDataTransport
     - GoogleUtilities
-    - libwebp
-    - Mantle
     - nanopb
     - PromisesObjC
     - SDWebImage
-    - SDWebImageWebPCoder
     - SwiftyGif
 
 EXTERNAL SOURCES:
@@ -191,8 +164,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_messaging/ios"
   Flutter:
     :path: Flutter
-  flutter_image_compress_common:
-    :path: ".symlinks/plugins/flutter_image_compress_common/ios"
   flutter_secure_storage_darwin:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   flutter_web_auth_2:
@@ -215,34 +186,30 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
-  firebase_core: ee30637e6744af8e0c12a6a1e8a9718506ec2398
-  firebase_messaging: 343de01a8d3e18b60df0c6d37f7174c44ae38e02
+  firebase_core: 8d5e24676350f15dd111aa59a88a1ae26605f9ba
+  firebase_messaging: 834cfc0887393d3108cdb19da8e57655c54fd0e4
   FirebaseCore: 0dbad74bda10b8fb9ca34ad8f375fb9dd3ebef7c
   FirebaseCoreInternal: fe5fa466aeb314787093a7dce9f0beeaad5a2a21
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseMessaging: 7f42cfd10ec64181db4e01b305a613791c8e782c
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_web_auth_2: 4091f1645696258ddc57849f62bef2a848fc313c
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_gallery_saver: 14711d79da40581063e8842a11acf1969d781ed7
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
-  Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
+  image_gallery_saver: cb43cc43141711190510e92c460eb1655cd343cb
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
+  receive_sharing_intent: 79c848f5b045674ad60b9fea3bafea59962ad2c1
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  SDWebImageWebPCoder: 0e06e365080397465cc73a7a9b472d8a3bd0f377
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: d57d795ecf1b65265eb65c139068699818742a94
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -9,20 +9,20 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
-		3714E380DD4D3AA92CA4A12C /* Pods_Share_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1614BEF3CFD15C471AED3C1C /* Pods_Share_Extension.framework */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
+		7BB27635EEF4BA7FF417656B /* Pods_Share_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B37BEAB946D67C9FC9B7094 /* Pods_Share_Extension.framework */; };
+		80CF5DC594D601CA14805034 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28E7461AFBAE0D742106BBBD /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		CE8B3C453EC9127CF89F106C /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4BA397A9019F307FF6F2B7D /* Pods_RunnerTests.framework */; };
 		D0A8C8AC5EE65B216FC1DCD6 /* TokenBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E27EA748E9EC5EEC16A811A /* TokenBridge.swift */; };
 		DB4BC0492F8F7EE200918EF1 /* Share Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = DB4BC03F2F8F7EE200918EF1 /* Share Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E1E8E9F2E8E5187684C15757 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2523613EF1D0B97C206D6B07 /* GoogleService-Info.plist */; };
-		E85A7AD063F97E740DF42DEB /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB56E8A40FA55EBFD2B383D8 /* Pods_RunnerTests.framework */; };
 		E8F4A1B12F8D00010000AB02 /* AppGroupConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4A1B12F8D00010000AB01 /* AppGroupConfig.swift */; };
 		E8F4A1B12F8D00010000AB03 /* AppGroupConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4A1B12F8D00010000AB01 /* AppGroupConfig.swift */; };
-		EB87E2BCDA30B2947BAA5991 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 01D814076A2B857BFE71A367 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,25 +67,22 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		01D814076A2B857BFE71A367 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0D9BE5EF1F76A94CECCA1F7A /* Pods-Share Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.debug.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		1614BEF3CFD15C471AED3C1C /* Pods_Share_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Share_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		164641BD4CEE6612DD535AE6 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		1B44AD26AB88970FCC1FE188 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		2523613EF1D0B97C206D6B07 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		28E7461AFBAE0D742106BBBD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		358C328AE4E4CDB1650B8D26 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3BD0E6B10F6748FCCAFF0175 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3ED31364B1E536D919781C2D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		4596B37E60D73A17258517BB /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		5EE0E9230AB6D716735AC9A6 /* Pods-Share Extension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.profile.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.profile.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		78F2E40EE61EF1C4F0A01020 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
-		8341F28E256015972F9433D1 /* Pods-Share Extension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.profile.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.profile.xcconfig"; sourceTree = "<group>"; };
+		7B37BEAB946D67C9FC9B7094 /* Pods_Share_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Share_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		96CBA1AEF3660D4B88642B2B /* Pods-Share Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.release.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -94,15 +91,18 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9E27EA748E9EC5EEC16A811A /* TokenBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TokenBridge.swift; sourceTree = "<group>"; };
-		B8DF1FCB07D09D3254197175 /* Pods-Share Extension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.release.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.release.xcconfig"; sourceTree = "<group>"; };
-		D170D99DE7A7DE4D767B7565 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		A6F5D94CCDA13F7056689214 /* Pods-Share Extension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Share Extension.debug.xcconfig"; path = "Target Support Files/Pods-Share Extension/Pods-Share Extension.debug.xcconfig"; sourceTree = "<group>"; };
+		D4BA397A9019F307FF6F2B7D /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D8CE94945372FD30754F05F3 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		DB4BC03F2F8F7EE200918EF1 /* Share Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Share Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8F4A1B12F8D00010000AB01 /* AppGroupConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroupConfig.swift; sourceTree = "<group>"; };
-		FB56E8A40FA55EBFD2B383D8 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB926EE4A179F84A549028EE /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EE489A1FD4A6B70A2787A763 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		F74E15A80E9189994A3C9B8E /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		DB4BC04E2F8F7EE200918EF1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		DB4BC04E2F8F7EE200918EF1 /* Exceptions for "Share Extension" folder in "Share Extension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -112,7 +112,18 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		DB4BC0402F8F7EE200918EF1 /* Share Extension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (DB4BC04E2F8F7EE200918EF1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Share Extension"; sourceTree = "<group>"; };
+		DB4BC0402F8F7EE200918EF1 /* Share Extension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				DB4BC04E2F8F7EE200918EF1 /* Exceptions for "Share Extension" folder in "Share Extension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = "Share Extension";
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,7 +131,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E85A7AD063F97E740DF42DEB /* Pods_RunnerTests.framework in Frameworks */,
+				CE8B3C453EC9127CF89F106C /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,7 +139,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EB87E2BCDA30B2947BAA5991 /* Pods_Runner.framework in Frameworks */,
+				80CF5DC594D601CA14805034 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -136,7 +147,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3714E380DD4D3AA92CA4A12C /* Pods_Share_Extension.framework in Frameworks */,
+				7BB27635EEF4BA7FF417656B /* Pods_Share_Extension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,15 +157,15 @@
 		1EA23120530829B2A92F0E9E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3ED31364B1E536D919781C2D /* Pods-Runner.debug.xcconfig */,
-				1B44AD26AB88970FCC1FE188 /* Pods-Runner.release.xcconfig */,
-				164641BD4CEE6612DD535AE6 /* Pods-Runner.profile.xcconfig */,
-				3BD0E6B10F6748FCCAFF0175 /* Pods-RunnerTests.debug.xcconfig */,
-				4596B37E60D73A17258517BB /* Pods-RunnerTests.release.xcconfig */,
-				D170D99DE7A7DE4D767B7565 /* Pods-RunnerTests.profile.xcconfig */,
-				0D9BE5EF1F76A94CECCA1F7A /* Pods-Share Extension.debug.xcconfig */,
-				B8DF1FCB07D09D3254197175 /* Pods-Share Extension.release.xcconfig */,
-				8341F28E256015972F9433D1 /* Pods-Share Extension.profile.xcconfig */,
+				D8CE94945372FD30754F05F3 /* Pods-Runner.debug.xcconfig */,
+				358C328AE4E4CDB1650B8D26 /* Pods-Runner.release.xcconfig */,
+				F74E15A80E9189994A3C9B8E /* Pods-Runner.profile.xcconfig */,
+				EB926EE4A179F84A549028EE /* Pods-RunnerTests.debug.xcconfig */,
+				EE489A1FD4A6B70A2787A763 /* Pods-RunnerTests.release.xcconfig */,
+				78F2E40EE61EF1C4F0A01020 /* Pods-RunnerTests.profile.xcconfig */,
+				A6F5D94CCDA13F7056689214 /* Pods-Share Extension.debug.xcconfig */,
+				96CBA1AEF3660D4B88642B2B /* Pods-Share Extension.release.xcconfig */,
+				5EE0E9230AB6D716735AC9A6 /* Pods-Share Extension.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -167,12 +178,12 @@
 			path = RunnerTests;
 			sourceTree = "<group>";
 		};
-		6F7FFA9AA68CC36975C45431 /* Frameworks */ = {
+		7EE5BE5C926CD69DD35F8075 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				01D814076A2B857BFE71A367 /* Pods_Runner.framework */,
-				FB56E8A40FA55EBFD2B383D8 /* Pods_RunnerTests.framework */,
-				1614BEF3CFD15C471AED3C1C /* Pods_Share_Extension.framework */,
+				28E7461AFBAE0D742106BBBD /* Pods_Runner.framework */,
+				D4BA397A9019F307FF6F2B7D /* Pods_RunnerTests.framework */,
+				7B37BEAB946D67C9FC9B7094 /* Pods_Share_Extension.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -199,7 +210,7 @@
 				331C8082294A63A400263BE5 /* RunnerTests */,
 				1EA23120530829B2A92F0E9E /* Pods */,
 				2523613EF1D0B97C206D6B07 /* GoogleService-Info.plist */,
-				6F7FFA9AA68CC36975C45431 /* Frameworks */,
+				7EE5BE5C926CD69DD35F8075 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -245,7 +256,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
-				AE8B5AABF437BEA763063F32 /* [CP] Check Pods Manifest.lock */,
+				6BFA23FFEC83C3566133FFE1 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
 				298D38F36620E7809D209A11 /* Frameworks */,
@@ -264,7 +275,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
-				9B33B950CFD69B8085E13AE6 /* [CP] Check Pods Manifest.lock */,
+				C0BA20CEEE9036DAB48D39CB /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
@@ -272,8 +283,8 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				DB4BC04A2F8F7EE200918EF1 /* Embed Foundation Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				EE8AB906367EE864D23C98FE /* [CP] Embed Pods Frameworks */,
-				D5825DB01C33B65A672CF6C4 /* [CP] Copy Pods Resources */,
+				04CC856A780179186EEEC3DF /* [CP] Embed Pods Frameworks */,
+				B9979D99095EC97EDC181B4B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -289,7 +300,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DB4BC04F2F8F7EE200918EF1 /* Build configuration list for PBXNativeTarget "Share Extension" */;
 			buildPhases = (
-				0E04165448D8AF94171CFC67 /* [CP] Check Pods Manifest.lock */,
+				2F2E89EFEA732713B32CC061 /* [CP] Check Pods Manifest.lock */,
 				DB4BC03B2F8F7EE200918EF1 /* Sources */,
 				DB4BC03C2F8F7EE200918EF1 /* Frameworks */,
 				DB4BC03D2F8F7EE200918EF1 /* Resources */,
@@ -380,7 +391,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0E04165448D8AF94171CFC67 /* [CP] Check Pods Manifest.lock */ = {
+		04CC856A780179186EEEC3DF /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2F2E89EFEA732713B32CC061 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -418,44 +446,7 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
-		9740EEB61CF901F6004384FC /* Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		9B33B950CFD69B8085E13AE6 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AE8B5AABF437BEA763063F32 /* [CP] Check Pods Manifest.lock */ = {
+		6BFA23FFEC83C3566133FFE1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -477,7 +468,22 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D5825DB01C33B65A672CF6C4 /* [CP] Copy Pods Resources */ = {
+		9740EEB61CF901F6004384FC /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		B9979D99095EC97EDC181B4B /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -485,38 +491,35 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EE8AB906367EE864D23C98FE /* [CP] Embed Pods Frameworks */ = {
+		C0BA20CEEE9036DAB48D39CB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -673,7 +676,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3BD0E6B10F6748FCCAFF0175 /* Pods-RunnerTests.debug.xcconfig */;
+			baseConfigurationReference = EB926EE4A179F84A549028EE /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -699,7 +702,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4596B37E60D73A17258517BB /* Pods-RunnerTests.release.xcconfig */;
+			baseConfigurationReference = EE489A1FD4A6B70A2787A763 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -723,7 +726,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D170D99DE7A7DE4D767B7565 /* Pods-RunnerTests.profile.xcconfig */;
+			baseConfigurationReference = 78F2E40EE61EF1C4F0A01020 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
@@ -927,7 +930,7 @@
 		};
 		DB4BC04B2F8F7EE200918EF1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D9BE5EF1F76A94CECCA1F7A /* Pods-Share Extension.debug.xcconfig */;
+			baseConfigurationReference = A6F5D94CCDA13F7056689214 /* Pods-Share Extension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -979,7 +982,7 @@
 		};
 		DB4BC04C2F8F7EE200918EF1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B8DF1FCB07D09D3254197175 /* Pods-Share Extension.release.xcconfig */;
+			baseConfigurationReference = 96CBA1AEF3660D4B88642B2B /* Pods-Share Extension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -1028,7 +1031,7 @@
 		};
 		DB4BC04D2F8F7EE200918EF1 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8341F28E256015972F9433D1 /* Pods-Share Extension.profile.xcconfig */;
+			baseConfigurationReference = 5EE0E9230AB6D716735AC9A6 /* Pods-Share Extension.profile.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";

--- a/lib/datasources/remote/home_remote_datasource.dart
+++ b/lib/datasources/remote/home_remote_datasource.dart
@@ -277,67 +277,9 @@ class HomeRemoteDatasource {
   }
 
   /// S3 업로드 완료 후 DB 저장 확정 (POST /attachments/confirm)
-  Future<List<ConfirmResponseItem>> confirmAttachment(
+  Future<void> confirmAttachment(
     ConfirmRequestDto request,
   ) async {
-    final response = await _apiClient.post(
-      ApiConstants.attachmentsConfirmEndpoint,
-      data: request.toJson(),
-    );
-    final data = response.data;
-    if (data is List) {
-      return data
-          .whereType<Map<String, dynamic>>()
-          .map(ConfirmResponseItem.fromJson)
-          .toList();
-    }
-    if (data is Map<String, dynamic>) {
-      return [ConfirmResponseItem.fromJson(data)];
-    }
-    return const <ConfirmResponseItem>[];
-  }
-
-  /// presigned URL 발급 (POST /attachments/presign)
-  Future<List<PresignResponseDto>> presignAttachment(
-    PresignRequestDto request,
-  ) async {
-    final response = await _apiClient.post(
-      ApiConstants.attachmentsPresignEndpoint,
-      data: request.toJson(),
-    );
-    final data = response.data;
-    if (data is List) {
-      return data
-          .whereType<Map<String, dynamic>>()
-          .map(PresignResponseDto.fromJson)
-          .toList();
-    }
-    return const [];
-  }
-
-  /// S3 직접 PUT 업로드 (인증 헤더 없이 별도 Dio 사용)
-  Future<void> uploadToS3({
-    required String uploadUrl,
-    required Uint8List bytes,
-    required String contentType,
-  }) async {
-    final rawDio = Dio();
-    await rawDio.put(
-      uploadUrl,
-      data: Stream<List<int>>.fromIterable([bytes]),
-      options: Options(
-        headers: {
-          Headers.contentTypeHeader: contentType,
-          Headers.contentLengthHeader: bytes.length,
-        },
-        contentType: contentType,
-        responseType: ResponseType.plain,
-      ),
-    );
-  }
-
-  /// 업로드 완료 확인 (POST /attachments/confirm)
-  Future<void> confirmAttachment(ConfirmRequestDto request) async {
     await _apiClient.post(
       ApiConstants.attachmentsConfirmEndpoint,
       data: request.toJson(),

--- a/lib/repositories/home_repository.dart
+++ b/lib/repositories/home_repository.dart
@@ -163,6 +163,71 @@ class HomeRepository {
     );
   }
 
+  /// 자료 이미지 추가 - 단건 (공유 확장 전용)
+  Future<void> createImage({
+    required List<int> foldersIdList,
+    required String textContent,
+    required List<int> imageBytes,
+    required String fileName,
+  }) async {
+    await createImages(
+      foldersIdList: foldersIdList,
+      textContent: textContent,
+      images: [(bytes: imageBytes, fileName: fileName)],
+    );
+  }
+
+  /// 자료 파일 추가 - 단건 (공유 확장 전용, presign → S3 PUT → confirm)
+  Future<void> createFile({
+    required List<int> foldersIdList,
+    required String textContent,
+    required List<int> fileBytes,
+    required String fileName,
+  }) async {
+    final contentType = resolveContentType(fileName);
+    final bytes = fileBytes is Uint8List
+        ? fileBytes as Uint8List
+        : Uint8List.fromList(fileBytes);
+
+    final presignedList = await _remoteDatasource.presignAttachment(
+      PresignRequestDto(
+        foldersIdList: foldersIdList,
+        attachmentsType: 'FILE',
+        textContent: textContent,
+        files: [
+          PresignFileDto(
+            contentType: contentType,
+            fileName: fileName,
+            fileSize: bytes.length,
+          ),
+        ],
+      ),
+    );
+    if (presignedList.isEmpty) throw Exception('presign 응답 없음');
+
+    await _remoteDatasource.uploadToS3(
+      uploadUrl: presignedList[0].uploadUrl,
+      bytes: bytes,
+      contentType: contentType,
+    );
+
+    await _remoteDatasource.confirmAttachment(
+      ConfirmRequestDto(
+        foldersIdList: foldersIdList,
+        attachmentsType: 'FILE',
+        textContent: textContent,
+        files: [
+          ConfirmFileDto(
+            objectKey: presignedList[0].objectKey,
+            fileName: fileName,
+            fileSize: bytes.length,
+            contentType: contentType,
+          ),
+        ],
+      ),
+    );
+  }
+
   /// 자료 이미지 추가 (presign → S3 PUT 병렬 → confirm)
   Future<({int presignMs, int s3Ms, int confirmMs, int totalMs})> createImages({
     required List<int> foldersIdList,

--- a/lib/repositories/home_repository.dart
+++ b/lib/repositories/home_repository.dart
@@ -163,39 +163,6 @@ class HomeRepository {
     );
   }
 
-  /// 자료 파일 추가 (presign → S3 PUT → confirm)
-  /// 기존 multipart 단일 호출을 presigned URL 기반 3단계로 교체
-  Future<List<ConfirmResponseItem>> createFile({
-    required List<int> foldersIdList,
-    required String textContent,
-    required List<int> fileBytes,
-    required String fileName,
-  }) async {
-    return _uploadViaPresign(
-      foldersIdList: foldersIdList,
-      textContent: textContent,
-      bytes: fileBytes,
-      fileName: fileName,
-      attachmentsType: AttachmentsType.file,
-    );
-  }
-
-  /// 자료 이미지 추가 (presign → S3 PUT → confirm) - 단일
-  Future<List<ConfirmResponseItem>> createImage({
-    required List<int> foldersIdList,
-    required String textContent,
-    required List<int> imageBytes,
-    required String fileName,
-  }) async {
-    return _uploadViaPresign(
-      foldersIdList: foldersIdList,
-      textContent: textContent,
-      bytes: imageBytes,
-      fileName: fileName,
-      attachmentsType: AttachmentsType.image,
-    );
-  }
-
   /// 자료 이미지 추가 (presign → S3 PUT 병렬 → confirm)
   Future<({int presignMs, int s3Ms, int confirmMs, int totalMs})> createImages({
     required List<int> foldersIdList,

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,7 +10,6 @@ import file_picker
 import file_selector_macos
 import firebase_core
 import firebase_messaging
-import flutter_image_compress_macos
 import flutter_secure_storage_darwin
 import flutter_web_auth_2
 import share_plus
@@ -24,7 +23,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
-  FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -382,54 +382,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.2.1"
-  flutter_image_compress:
-    dependency: "direct main"
-    description:
-      name: flutter_image_compress
-      sha256: "51d23be39efc2185e72e290042a0da41aed70b14ef97db362a6b5368d0523b27"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
-  flutter_image_compress_common:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_common
-      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.6"
-  flutter_image_compress_macos:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_macos
-      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
-  flutter_image_compress_ohos:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_ohos
-      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
-  flutter_image_compress_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_platform_interface
-      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
-  flutter_image_compress_web:
-    dependency: transitive
-    description:
-      name: flutter_image_compress_web
-      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.5"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,11 +54,8 @@ dependencies:
   flutter_dotenv: ^5.1.0
   flutter_svg: ^2.2.3
 
-  flutter_image_compress: ^2.1.0
-
   # 파일/이미지 선택 (시뮬레이터·실기기 동일 로직)
   image_picker: ^1.0.7
-  flutter_image_compress: ^2.3.0
   file_picker: ^11.0.2
   flutter_web_auth_2: ^5.0.2
   flutter_secure_storage: ^10.0.0


### PR DESCRIPTION
- home_remote_datasource: presignAttachment/uploadToS3/confirmAttachment 중복 선언 제거
- home_remote_datasource: confirmAttachment 반환 타입을 void로 수정 (ConfirmResponseItem 미정의)
- home_repository: createFile/createImage 제거 (_uploadViaPresign, AttachmentsType 미정의)