### PR TITLE
refactor: CalendarScreen 네비게이션 정리 및 캘린더 기능 개선

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -102,7 +102,7 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		DB4BC04E2F8F7EE200918EF1 /* Exceptions for "Share Extension" folder in "Share Extension" target */ = {
+		DB4BC04E2F8F7EE200918EF1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -112,18 +112,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		DB4BC0402F8F7EE200918EF1 /* Share Extension */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				DB4BC04E2F8F7EE200918EF1 /* Exceptions for "Share Extension" folder in "Share Extension" target */,
-			);
-			explicitFileTypes = {
-			};
-			explicitFolders = (
-			);
-			path = "Share Extension";
-			sourceTree = "<group>";
-		};
+		DB4BC0402F8F7EE200918EF1 /* Share Extension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (DB4BC04E2F8F7EE200918EF1 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Share Extension"; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -399,9 +388,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -491,9 +484,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -648,10 +645,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = toIT;
@@ -663,6 +662,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT Runner Dev Profile Sangwoo";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -680,9 +680,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.RunnerTests;
@@ -706,9 +706,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.RunnerTests;
@@ -730,9 +730,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.RunnerTests;
@@ -867,10 +867,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = toIT;
@@ -882,6 +884,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT Runner Dev Profile Sangwoo";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -902,10 +905,12 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = toIT;
@@ -917,6 +922,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT Runner Dev Profile Sangwoo";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -940,10 +946,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -964,6 +972,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT ShareExtension Dev Profile Sangwoo";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -992,10 +1001,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1015,6 +1026,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT ShareExtension Dev Profile Sangwoo";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1041,10 +1053,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = 86MPU972PJ;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1064,6 +1078,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT ShareExtension Dev Profile Sangwoo";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/lib/views/screens/calendar_screen.dart
+++ b/lib/views/screens/calendar_screen.dart
@@ -12,6 +12,26 @@ import '../widgets/home/home_app_bar.dart';
 class CalendarScreen extends ConsumerWidget {
   const CalendarScreen({super.key});
 
+  void _openMy(BuildContext context) {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute<void>(builder: (_) => const MyScreen()));
+  }
+
+  void _openSearch(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(builder: (_) => const SearchScreen()),
+    );
+  }
+
+  void _openNotifications(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const NotificationScreen(),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
@@ -20,23 +40,9 @@ class CalendarScreen extends ConsumerWidget {
         preferredSize: const Size.fromHeight(56),
         child: HomeAppBar(
           title: '캘린더',
-          onMenuPressed: () {
-            Navigator.of(
-              context,
-            ).push(MaterialPageRoute<void>(builder: (_) => const MyScreen()));
-          },
-          onSearchPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(builder: (_) => const SearchScreen()),
-            );
-          },
-          onNotificationPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => const NotificationScreen(),
-              ),
-            );
-          },
+          onMenuPressed: () => _openMy(context),
+          onSearchPressed: () => _openSearch(context),
+          onNotificationPressed: () => _openNotifications(context),
         ),
       ),
       body: const CalendarWidget(),

--- a/lib/views/widgets/calendar/calendar_constants.dart
+++ b/lib/views/widgets/calendar/calendar_constants.dart
@@ -1,0 +1,27 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// 업로드 배너 등 고정 inset용 최소값
+const double kCalendarBottomNavReserve = 84.0;
+
+const double kCalendarNavBarContentHeight = 52.0;
+const double kCalendarNavBarTopPadding = 8.0;
+const double kCalendarScrollBottomExtra = 20.0;
+
+/// 스크롤 끝에서 하단 네비·시스템 inset을 피하기 위한 padding
+double calendarScrollBottomPadding(BuildContext context) {
+  final mq = MediaQuery.of(context);
+  final platform = Theme.of(context).platform;
+  final systemBottom = math.max(
+    math.max(mq.viewPadding.bottom, mq.padding.bottom),
+    mq.systemGestureInsets.bottom,
+  );
+  final navGap = platform == TargetPlatform.android ? 12.0 : 8.0;
+
+  return systemBottom +
+      navGap +
+      kCalendarNavBarTopPadding +
+      kCalendarNavBarContentHeight +
+      kCalendarScrollBottomExtra;
+}

--- a/lib/views/widgets/calendar/calendar_grid.dart
+++ b/lib/views/widgets/calendar/calendar_grid.dart
@@ -6,6 +6,7 @@ import '../../../core/constants/app_colors.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/utils/calendar_utils.dart';
 import '../../../models/calendar/calendar_event.dart';
+import 'calendar_constants.dart';
 import 'calendar_day_cell.dart';
 import 'event_chip.dart';
 
@@ -36,7 +37,7 @@ class CalendarGrid extends ConsumerWidget {
         _buildWeekdayHeader(),
         // 날짜 그리드
         Expanded(
-          child: _buildDaysGrid(days, eventIndex),
+          child: _buildDaysGrid(context, days, eventIndex),
         ),
       ],
     );
@@ -74,22 +75,26 @@ class CalendarGrid extends ConsumerWidget {
 
   /// 날짜 그리드 위젯
   Widget _buildDaysGrid(
+    BuildContext context,
     List<DateTime> days,
     CalendarEventIndex eventIndex,
   ) {
-    // 주(week) 단위로 분할
+    final bottomPad = calendarScrollBottomPadding(context);
     final weeks = <List<DateTime>>[];
     for (var i = 0; i < days.length; i += 7) {
       weeks.add(days.sublist(i, i + 7));
     }
 
     return SingleChildScrollView(
-      physics: const ClampingScrollPhysics(),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: weeks
-            .map((week) => _buildWeekRow(week, eventIndex))
-            .toList(),
+      physics: const AlwaysScrollableScrollPhysics(),
+      child: Padding(
+        padding: EdgeInsets.only(bottom: bottomPad),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: weeks
+              .map((week) => _buildWeekRow(week, eventIndex))
+              .toList(),
+        ),
       ),
     );
   }

--- a/lib/views/widgets/calendar/calendar_widget.dart
+++ b/lib/views/widgets/calendar/calendar_widget.dart
@@ -6,6 +6,7 @@ import '../../../controllers/calendar_controller.dart';
 import '../../../services/schedule_api_client.dart' show scheduleApiClientProvider;
 import 'calendar_grid.dart';
 import 'calendar_header.dart';
+import 'calendar_year_month_picker.dart';
 import 'day_events_bottom_sheet.dart';
 
 /// 메인 캘린더 위젯
@@ -86,115 +87,6 @@ class _CalendarWidgetState extends ConsumerState<CalendarWidget> {
     showDayEventsBottomSheet(context, date, dayEvents);
   }
 
-  /// 년/월 선택 피커 (딤 없음, 월 라벨 바로 아래 · 그림자만으로 떠 보이게)
-  void _showYearMonthPicker(BuildContext context, DateTime currentMonth) {
-    var selectedYear = currentMonth.year;
-    var selectedMonth = currentMonth.month;
-
-    final mediaQuery = MediaQuery.of(context);
-    final overlayState = Overlay.of(context);
-    final overlayBox =
-        overlayState.context.findRenderObject() as RenderBox?;
-
-    const horizontalPad = 20.0;
-    final screenW = mediaQuery.size.width;
-    final panelWidth = (screenW - horizontalPad * 2).clamp(260.0, 320.0);
-
-    double panelLeft = (screenW - panelWidth) / 2;
-    double panelTop = mediaQuery.padding.top + 56 + 48;
-
-    final anchorCtx = _monthAnchorKey.currentContext;
-    if (anchorCtx != null &&
-        overlayBox != null &&
-        overlayBox.attached) {
-      final anchorBox = anchorCtx.findRenderObject() as RenderBox?;
-      if (anchorBox != null && anchorBox.attached) {
-        final origin = anchorBox.localToGlobal(
-          Offset.zero,
-          ancestor: overlayBox,
-        );
-        final centerX = origin.dx + anchorBox.size.width / 2;
-        panelLeft = (centerX - panelWidth / 2).clamp(
-          horizontalPad,
-          screenW - horizontalPad - panelWidth,
-        );
-        panelTop = origin.dy + anchorBox.size.height + 8;
-      }
-    }
-
-    showGeneralDialog<void>(
-      context: context,
-      barrierDismissible: true,
-      barrierLabel:
-          MaterialLocalizations.of(context).modalBarrierDismissLabel,
-      barrierColor: Colors.transparent,
-      transitionDuration: Duration.zero,
-      pageBuilder: (dialogContext, animation, secondaryAnimation) {
-        return Material(
-          type: MaterialType.transparency,
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: [
-              Positioned.fill(
-                child: GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onTap: () => Navigator.of(dialogContext).pop(),
-                ),
-              ),
-              Positioned(
-                left: panelLeft,
-                top: panelTop,
-                width: panelWidth,
-                height: 292,
-                child: GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onTap: () {},
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: AppColors.surface,
-                      borderRadius: BorderRadius.circular(20),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.2),
-                          offset: const Offset(0, 10),
-                          blurRadius: 28,
-                          spreadRadius: 0,
-                        ),
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.1),
-                          offset: const Offset(0, 4),
-                          blurRadius: 12,
-                        ),
-                      ],
-                    ),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(20),
-                      child: _YearMonthWheelPicker(
-                        initialMonth: currentMonth,
-                        onSelectionChanged: (y, m) {
-                          selectedYear = y;
-                          selectedMonth = m;
-                        },
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        );
-      },
-    ).then((_) {
-      if (!context.mounted) return;
-      final unchanged = selectedYear == currentMonth.year &&
-          selectedMonth == currentMonth.month;
-      if (unchanged) return;
-      ref.read(calendarProvider.notifier).goToMonth(
-            DateTime(selectedYear, selectedMonth, 1),
-          );
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     // 헤더용 focusedMonth, 로딩 상태 watch
@@ -239,15 +131,20 @@ class _CalendarWidgetState extends ConsumerState<CalendarWidget> {
       children: [
         Column(
           children: [
-            // 헤더
             CalendarHeader(
-              monthSelectorKey: _monthAnchorKey,
-              focusedMonth: focusedMonth,
-              onMonthTap: () {
-                _showYearMonthPicker(context, focusedMonth);
-              },
-            ),
-            // 캘린더 본체 (스와이프 가능)
+                monthSelectorKey: _monthAnchorKey,
+                focusedMonth: focusedMonth,
+                onMonthTap: () {
+                  showCalendarYearMonthPicker(
+                    context,
+                    ref,
+                    anchorKey: _monthAnchorKey,
+                    currentMonth: focusedMonth,
+                    fallbackPanelTop:
+                        MediaQuery.paddingOf(context).top + 56 + 48,
+                  );
+                },
+              ),
             Expanded(
               child: PageView.builder(
             controller: _pageController,
@@ -284,138 +181,6 @@ class _CalendarWidgetState extends ConsumerState<CalendarWidget> {
             ),
           ),
       ],
-    );
-  }
-}
-
-/// 년·월 휠 (스크롤 컨트롤러 생명주기 분리)
-class _YearMonthWheelPicker extends StatefulWidget {
-  const _YearMonthWheelPicker({
-    required this.initialMonth,
-    required this.onSelectionChanged,
-  });
-
-  final DateTime initialMonth;
-  final void Function(int year, int month) onSelectionChanged;
-
-  @override
-  State<_YearMonthWheelPicker> createState() =>
-      _YearMonthWheelPickerState();
-}
-
-class _YearMonthWheelPickerState extends State<_YearMonthWheelPicker> {
-  static const int _yearBase = 2020;
-  static const int _yearCount = 20;
-
-  late int _selectedYear;
-  late int _selectedMonth;
-  late FixedExtentScrollController _yearController;
-  late FixedExtentScrollController _monthController;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedYear = widget.initialMonth.year;
-    _selectedMonth = widget.initialMonth.month;
-    _yearController = FixedExtentScrollController(
-      initialItem: (_selectedYear - _yearBase).clamp(0, _yearCount - 1),
-    );
-    _monthController = FixedExtentScrollController(
-      initialItem: _selectedMonth - 1,
-    );
-  }
-
-  @override
-  void dispose() {
-    _yearController.dispose();
-    _monthController.dispose();
-    super.dispose();
-  }
-
-  void _emit() {
-    widget.onSelectionChanged(_selectedYear, _selectedMonth);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Row(
-        children: [
-          Expanded(
-            child: ListWheelScrollView.useDelegate(
-              controller: _yearController,
-              itemExtent: 44,
-              perspective: 0.005,
-              diameterRatio: 1.5,
-              physics: const FixedExtentScrollPhysics(),
-              onSelectedItemChanged: (index) {
-                setState(() {
-                  _selectedYear = _yearBase + index;
-                });
-                _emit();
-              },
-              childDelegate: ListWheelChildBuilderDelegate(
-                childCount: _yearCount,
-                builder: (context, index) {
-                  final year = _yearBase + index;
-                  final isSelected = year == _selectedYear;
-                  return Center(
-                    child: Text(
-                      '$year년',
-                      style: TextStyle(
-                        fontSize: isSelected ? 20 : 16,
-                        fontWeight: isSelected
-                            ? FontWeight.bold
-                            : FontWeight.normal,
-                        color: isSelected
-                            ? AppColors.gray900
-                            : AppColors.gray600,
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
-          Expanded(
-            child: ListWheelScrollView.useDelegate(
-              controller: _monthController,
-              itemExtent: 44,
-              perspective: 0.005,
-              diameterRatio: 1.5,
-              physics: const FixedExtentScrollPhysics(),
-              onSelectedItemChanged: (index) {
-                setState(() {
-                  _selectedMonth = index + 1;
-                });
-                _emit();
-              },
-              childDelegate: ListWheelChildBuilderDelegate(
-                childCount: 12,
-                builder: (context, index) {
-                  final month = index + 1;
-                  final isSelected = month == _selectedMonth;
-                  return Center(
-                    child: Text(
-                      '$month월',
-                      style: TextStyle(
-                        fontSize: isSelected ? 20 : 16,
-                        fontWeight: isSelected
-                            ? FontWeight.bold
-                            : FontWeight.normal,
-                        color: isSelected
-                            ? AppColors.gray900
-                            : AppColors.gray600,
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/views/widgets/calendar/calendar_year_month_picker.dart
+++ b/lib/views/widgets/calendar/calendar_year_month_picker.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../controllers/calendar_controller.dart';
+import '../../../core/constants/app_colors.dart';
+
+/// 년·월 오버레이 피커 표시
+Future<void> showCalendarYearMonthPicker(
+  BuildContext context,
+  WidgetRef ref, {
+  required DateTime currentMonth,
+  GlobalKey? anchorKey,
+  double fallbackPanelTop = 0,
+}) async {
+  var selectedYear = currentMonth.year;
+  var selectedMonth = currentMonth.month;
+
+  final mediaQuery = MediaQuery.of(context);
+  final overlayState = Overlay.of(context);
+  final overlayBox =
+      overlayState.context.findRenderObject() as RenderBox?;
+
+  const horizontalPad = 20.0;
+  final screenW = mediaQuery.size.width;
+  final panelWidth = (screenW - horizontalPad * 2).clamp(260.0, 320.0);
+
+  double panelLeft = (screenW - panelWidth) / 2;
+  double panelTop = fallbackPanelTop > 0
+      ? fallbackPanelTop
+      : mediaQuery.padding.top + 56;
+
+  final anchorCtx = anchorKey?.currentContext;
+  if (anchorCtx != null &&
+      overlayBox != null &&
+      overlayBox.attached) {
+    final anchorBox = anchorCtx.findRenderObject() as RenderBox?;
+    if (anchorBox != null && anchorBox.attached) {
+      final origin = anchorBox.localToGlobal(
+        Offset.zero,
+        ancestor: overlayBox,
+      );
+      final centerX = origin.dx + anchorBox.size.width / 2;
+      panelLeft = (centerX - panelWidth / 2).clamp(
+        horizontalPad,
+        screenW - horizontalPad - panelWidth,
+      );
+      panelTop = origin.dy + anchorBox.size.height + 8;
+    }
+  }
+
+  await showGeneralDialog<void>(
+    context: context,
+    barrierDismissible: true,
+    barrierLabel:
+        MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    barrierColor: Colors.transparent,
+    transitionDuration: Duration.zero,
+    pageBuilder: (dialogContext, animation, secondaryAnimation) {
+      return Material(
+        type: MaterialType.transparency,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: () => Navigator.of(dialogContext).pop(),
+              ),
+            ),
+            Positioned(
+              left: panelLeft,
+              top: panelTop,
+              width: panelWidth,
+              height: 292,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () {},
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius: BorderRadius.circular(20),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.2),
+                        offset: const Offset(0, 10),
+                        blurRadius: 28,
+                      ),
+                      BoxShadow(
+                        color: Colors.black.withValues(alpha: 0.1),
+                        offset: const Offset(0, 4),
+                        blurRadius: 12,
+                      ),
+                    ],
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(20),
+                    child: CalendarYearMonthWheelPicker(
+                      initialMonth: currentMonth,
+                      onSelectionChanged: (y, m) {
+                        selectedYear = y;
+                        selectedMonth = m;
+                      },
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    },
+  );
+
+  if (!context.mounted) return;
+  final unchanged = selectedYear == currentMonth.year &&
+      selectedMonth == currentMonth.month;
+  if (unchanged) return;
+  ref.read(calendarProvider.notifier).goToMonth(
+        DateTime(selectedYear, selectedMonth, 1),
+      );
+}
+
+/// 년·월 휠 피커
+class CalendarYearMonthWheelPicker extends StatefulWidget {
+  const CalendarYearMonthWheelPicker({
+    super.key,
+    required this.initialMonth,
+    required this.onSelectionChanged,
+  });
+
+  final DateTime initialMonth;
+  final void Function(int year, int month) onSelectionChanged;
+
+  @override
+  State<CalendarYearMonthWheelPicker> createState() =>
+      _CalendarYearMonthWheelPickerState();
+}
+
+class _CalendarYearMonthWheelPickerState
+    extends State<CalendarYearMonthWheelPicker> {
+  static const int _yearBase = 2020;
+  static const int _yearCount = 20;
+
+  late int _selectedYear;
+  late int _selectedMonth;
+  late FixedExtentScrollController _yearController;
+  late FixedExtentScrollController _monthController;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedYear = widget.initialMonth.year;
+    _selectedMonth = widget.initialMonth.month;
+    _yearController = FixedExtentScrollController(
+      initialItem: (_selectedYear - _yearBase).clamp(0, _yearCount - 1),
+    );
+    _monthController = FixedExtentScrollController(
+      initialItem: _selectedMonth - 1,
+    );
+  }
+
+  @override
+  void dispose() {
+    _yearController.dispose();
+    _monthController.dispose();
+    super.dispose();
+  }
+
+  void _emit() {
+    widget.onSelectionChanged(_selectedYear, _selectedMonth);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Expanded(
+            child: ListWheelScrollView.useDelegate(
+              controller: _yearController,
+              itemExtent: 44,
+              perspective: 0.005,
+              diameterRatio: 1.5,
+              physics: const FixedExtentScrollPhysics(),
+              onSelectedItemChanged: (index) {
+                setState(() {
+                  _selectedYear = _yearBase + index;
+                });
+                _emit();
+              },
+              childDelegate: ListWheelChildBuilderDelegate(
+                childCount: _yearCount,
+                builder: (context, index) {
+                  final year = _yearBase + index;
+                  final isSelected = year == _selectedYear;
+                  return Center(
+                    child: Text(
+                      '$year년',
+                      style: TextStyle(
+                        fontSize: isSelected ? 20 : 16,
+                        fontWeight: isSelected
+                            ? FontWeight.bold
+                            : FontWeight.normal,
+                        color: isSelected
+                            ? AppColors.gray900
+                            : AppColors.gray600,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+          Expanded(
+            child: ListWheelScrollView.useDelegate(
+              controller: _monthController,
+              itemExtent: 44,
+              perspective: 0.005,
+              diameterRatio: 1.5,
+              physics: const FixedExtentScrollPhysics(),
+              onSelectedItemChanged: (index) {
+                setState(() {
+                  _selectedMonth = index + 1;
+                });
+                _emit();
+              },
+              childDelegate: ListWheelChildBuilderDelegate(
+                childCount: 12,
+                builder: (context, index) {
+                  final month = index + 1;
+                  final isSelected = month == _selectedMonth;
+                  return Center(
+                    child: Text(
+                      '$month월',
+                      style: TextStyle(
+                        fontSize: isSelected ? 20 : 16,
+                        fontWeight: isSelected
+                            ? FontWeight.bold
+                            : FontWeight.normal,
+                        color: isSelected
+                            ? AppColors.gray900
+                            : AppColors.gray600,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/home/home_app_bar.dart
+++ b/lib/views/widgets/home/home_app_bar.dart
@@ -13,6 +13,7 @@ class HomeAppBar extends ConsumerWidget {
   const HomeAppBar({
     super.key,
     this.title = '마이',
+    this.titleWidget,
     this.onMenuPressed,
     this.onSearchPressed,
     this.onNotificationPressed,
@@ -20,6 +21,9 @@ class HomeAppBar extends ConsumerWidget {
   });
 
   final String title;
+
+  /// 지정 시 [title] 대신 표시 (캘린더 preview 등)
+  final Widget? titleWidget;
 
   /// `true`면 희미한 아이콘(흰색) — 그라데이션/어두운 상단 배경용(홈).
   /// `false`면 어두운 아이콘 — 밝은 배경용(캘린더).
@@ -60,14 +64,17 @@ class HomeAppBar extends ConsumerWidget {
             icon: const Icon(Icons.menu, color: AppColors.gray900),
           ),
           const SizedBox(width: 0),
-          Text(
-            title,
-            style: const TextStyle(
-              color: AppColors.gray900,
-              fontSize: 20,
-              fontWeight: FontWeight.w700,
+          if (titleWidget != null)
+            titleWidget!
+          else
+            Text(
+              title,
+              style: const TextStyle(
+                color: AppColors.gray900,
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+              ),
             ),
-          ),
           const Spacer(),
           IconButton(
             icon: Image.asset(AppAssets.searchIcon, width: 24, height: 24),


### PR DESCRIPTION
CalendarScreen 네비게이션 동작을 전용 메서드로 분리해 가독성을 높였습니다.
캘린더 레이아웃·패딩용 상수를 추가해 UI 일관성을 개선했습니다.
년·월 선택을 위한 피커 오버레이를 구현했습니다.
CalendarGrid가 새 패딩 상수를 사용하도록 수정해 레이아웃을 정리했습니다.
CalendarWidget의 구식 년·월 피커 코드를 제거해 구조를 단순화했습니다.