### PR TITLE
feat: 캘린더 이벤트 캐싱 및 프리패치 기능 추가

### DIFF
--- a/lib/controllers/calendar_controller.dart
+++ b/lib/controllers/calendar_controller.dart
@@ -402,7 +402,12 @@ class CalendarState with _$CalendarState {
 
 /// 캘린더 컨트롤러 (Notifier)
 class CalendarController extends Notifier<CalendarState> {
+  static const _cacheTtl = Duration(minutes: 5);
+  static const _maxCachedMonths = 12;
+
   late final ScheduleApiClient _apiClient;
+  final Map<String, _CalendarCacheEntry> _monthCache = {};
+  final Map<String, Future<List<CalendarEvent>>> _inFlightRequests = {};
 
   /// 스플래시 단계에서 주입된 프리패치를 이미 state 에 반영했음을 가리킨다.
   /// 최초 `loadEvents` 한 번은 같은 달에 대해 스킵하기 위한 1회성 플래그.
@@ -427,6 +432,7 @@ class CalendarController extends Notifier<CalendarState> {
         // 'events=${prefetched.events.length}',
       // );
       _primed = true;
+      _putCache(getMonthKey(focusedMonth), prefetched.events);
       // Riverpod 은 build() 도중 다른 Provider 의 state 수정을 금지하므로
       // 캐시 초기화는 한 틱 뒤로 미룬다(홈 프리패치와 동일한 패턴).
       Future<void>.microtask(() {
@@ -456,21 +462,35 @@ class CalendarController extends Notifier<CalendarState> {
         targetMonth.month == state.focusedMonth.month) {
       // debugPrint('[BOOT] calendar_loadEvents_skipped reason=primed_same_month');
       _primed = false;
+      _prefetchAdjacentMonths(targetMonth);
       return;
     }
-    state = state.copyWith(isLoading: true);
+
+    final cacheKey = getMonthKey(targetMonth);
+    final cached = _monthCache[cacheKey];
+    final hasFreshCache = cached != null && !cached.isExpired;
+
+    state = state.copyWith(
+      focusedMonth: targetMonth,
+      events: cached?.events ?? state.events,
+      isLoading: cached == null,
+    );
+    if (hasFreshCache) {
+      _touchCache(cacheKey, cached);
+      return;
+    }
+
     try {
-      final startDate = targetMonth;
-      final endDate = DateTime(targetMonth.year, targetMonth.month + 1, 0);
-      final events = await _apiClient.searchSchedules(
-        startDate: startDate,
-        endDate: endDate,
-      );
+      final events = await _fetchMonth(targetMonth);
+      if (state.focusedMonth.year != targetMonth.year ||
+          state.focusedMonth.month != targetMonth.month) {
+        return;
+      }
       state = state.copyWith(
-        focusedMonth: targetMonth,
         events: events,
         isLoading: false,
       );
+      _prefetchAdjacentMonths(targetMonth);
     } catch (e) {
       // debugPrint('일정 로드 실패: $e');
       state = state.copyWith(isLoading: false);
@@ -502,6 +522,24 @@ class CalendarController extends Notifier<CalendarState> {
     loadEvents(DateTime(month.year, month.month, 1));
   }
 
+  /// 생성된 일정의 시작 월과 날짜를 즉시 보여준다.
+  /// 캐시가 없더라도 생성 응답을 먼저 그린 뒤 서버 데이터는 백그라운드로 맞춘다.
+  void revealCreatedEvent(CalendarEvent event) {
+    final targetMonth = DateTime(event.startDate.year, event.startDate.month, 1);
+    final cacheKey = getMonthKey(targetMonth);
+    final cachedEvents = _monthCache[cacheKey]?.events ?? const <CalendarEvent>[];
+    final visibleEvents = _upsertEvent(cachedEvents, event);
+    _putCache(cacheKey, visibleEvents);
+
+    state = state.copyWith(
+      focusedMonth: targetMonth,
+      selectedDate: event.startDate,
+      events: visibleEvents,
+      isLoading: false,
+    );
+    _refreshMonthInBackground(targetMonth, keepEvent: event);
+  }
+
   /// 날짜 선택
   void selectDate(DateTime date) {
     state = state.copyWith(selectedDate: date);
@@ -510,6 +548,12 @@ class CalendarController extends Notifier<CalendarState> {
   /// 일정 추가
   void addEvent(CalendarEvent event) {
     state = state.copyWith(events: [...state.events, event]);
+    for (final entry in _monthCache.entries.toList()) {
+      final month = _monthFromKey(entry.key);
+      if (_eventIntersectsVisibleMonth(event, month)) {
+        _putCache(entry.key, _upsertEvent(entry.value.events, event));
+      }
+    }
   }
 
   /// 일정 삭제
@@ -525,6 +569,98 @@ class CalendarController extends Notifier<CalendarState> {
       events: state.events.map((e) => e.id == event.id ? event : e).toList(),
     );
   }
+
+  Future<List<CalendarEvent>> _fetchMonth(DateTime month) {
+    final cacheKey = getMonthKey(month);
+    return _inFlightRequests.putIfAbsent(cacheKey, () async {
+      try {
+        final days = CalendarUtils.getDaysInMonth(month);
+        final events = await _apiClient.searchSchedules(
+          startDate: days.first,
+          endDate: days.last,
+        );
+        _putCache(cacheKey, events);
+        return events;
+      } finally {
+        _inFlightRequests.remove(cacheKey);
+      }
+    });
+  }
+
+  void _refreshMonthInBackground(
+    DateTime month, {
+    CalendarEvent? keepEvent,
+  }) {
+    _fetchMonth(month).then((events) {
+      final refreshedEvents = keepEvent == null
+          ? events
+          : _upsertEvent(events, keepEvent);
+      if (keepEvent != null) {
+        _putCache(getMonthKey(month), refreshedEvents);
+      }
+      if (state.focusedMonth.year == month.year &&
+          state.focusedMonth.month == month.month) {
+        state = state.copyWith(events: refreshedEvents, isLoading: false);
+      }
+    }).catchError((Object _) {});
+  }
+
+  void _prefetchAdjacentMonths(DateTime month) {
+    for (final adjacent in [
+      DateTime(month.year, month.month - 1, 1),
+      DateTime(month.year, month.month + 1, 1),
+    ]) {
+      final cached = _monthCache[getMonthKey(adjacent)];
+      if (cached == null || cached.isExpired) {
+        _fetchMonth(adjacent).catchError((Object _) => <CalendarEvent>[]);
+      }
+    }
+  }
+
+  void _putCache(String key, List<CalendarEvent> events) {
+    _monthCache.remove(key);
+    _monthCache[key] = _CalendarCacheEntry(
+      events: events,
+      cachedAt: DateTime.now(),
+    );
+    while (_monthCache.length > _maxCachedMonths) {
+      _monthCache.remove(_monthCache.keys.first);
+    }
+  }
+
+  void _touchCache(String key, _CalendarCacheEntry entry) {
+    _monthCache.remove(key);
+    _monthCache[key] = entry;
+  }
+
+  static List<CalendarEvent> _upsertEvent(
+    List<CalendarEvent> events,
+    CalendarEvent event,
+  ) => [
+    ...events.where((existing) => existing.id != event.id),
+    event,
+  ];
+
+  static DateTime _monthFromKey(String key) {
+    final parts = key.split('-');
+    return DateTime(int.parse(parts[0]), int.parse(parts[1]), 1);
+  }
+
+  static bool _eventIntersectsVisibleMonth(CalendarEvent event, DateTime month) {
+    final days = CalendarUtils.getDaysInMonth(month);
+    return !event.endDate.isBefore(days.first) &&
+        !event.startDate.isAfter(days.last);
+  }
+}
+
+class _CalendarCacheEntry {
+  const _CalendarCacheEntry({required this.events, required this.cachedAt});
+
+  final List<CalendarEvent> events;
+  final DateTime cachedAt;
+
+  bool get isExpired =>
+      DateTime.now().difference(cachedAt) > CalendarController._cacheTtl;
 }
 
 /// 스플래시 부트스트랩에서 선요청해둔 현재월 일정 응답을 1회 주입하는 캐시.

--- a/lib/controllers/home_controller.dart
+++ b/lib/controllers/home_controller.dart
@@ -194,7 +194,9 @@ FolderItem _mapFolder(FolderDto dto, int index, {String countText = '0개'}) {
 
 /// 홈 화면 컨트롤러 (Notifier)
 class HomeController extends Notifier<HomeState> {
-  static const int maxFolderCount = 20;
+  static const int maxFolderCount = 100;
+  static const String folderLimitMessage =
+      '보관함은 최대 $maxFolderCount개까지 생성할 수 있습니다.';
   static const String allFilterToken = '__all__';
   static const String favoriteFilterToken = '__favorite__';
   static const String folderFilterPrefix = '__folder__';
@@ -371,7 +373,7 @@ class HomeController extends Notifier<HomeState> {
     required int iconIndex,
   }) async {
     if (state.folders.length >= maxFolderCount) {
-      state = state.copyWith(errorMessage: '보관함은 최대 20개까지 생성할 수 있습니다.');
+      state = state.copyWith(errorMessage: folderLimitMessage);
       return false;
     }
 

--- a/lib/views/screens/main_screen.dart
+++ b/lib/views/screens/main_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/utils/system_ui_insets.dart';
+import '../../controllers/calendar_controller.dart';
 import '../widgets/common/add_action_button.dart';
 import '../widgets/common/add_context_menu.dart';
 import '../widgets/common/glass_nav_bar.dart';
@@ -94,6 +95,11 @@ class _MainScreenState extends ConsumerState<MainScreen> {
         .push(MaterialPageRoute(builder: (_) => const EventFormScreen()))
         .then((result) {
           if (result == null) return;
+          if (result.isCreate == true) {
+            ref
+                .read(calendarProvider.notifier)
+                .revealCreatedEvent(result.event);
+          }
           ref.read(currentTabProvider.notifier).state = 1;
         });
   }

--- a/lib/views/screens/navigation_shell.dart
+++ b/lib/views/screens/navigation_shell.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
+import '../../controllers/calendar_controller.dart';
 import '../../controllers/home_controller.dart';
 import '../../core/constants/folder_tab_index.dart';
 import '../../core/deep_link/toit_deep_link_opener.dart';
@@ -375,6 +376,11 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
                         )
                         .then((result) {
                           if (result != null) {
+                            if (result.isCreate == true) {
+                              ref
+                                  .read(calendarProvider.notifier)
+                                  .revealCreatedEvent(result.event);
+                            }
                             ref.read(currentTabIndexProvider.notifier).state = 1;
                           }
                         });

--- a/lib/views/widgets/calendar/calendar_widget.dart
+++ b/lib/views/widgets/calendar/calendar_widget.dart
@@ -3,7 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/constants/app_colors.dart';
 import '../../../controllers/calendar_controller.dart';
-import '../../../services/schedule_api_client.dart' show scheduleApiClientProvider;
+import '../../../services/schedule_api_client.dart'
+    show scheduleApiClientProvider;
 import 'calendar_grid.dart';
 import 'calendar_header.dart';
 import 'calendar_year_month_picker.dart';
@@ -84,7 +85,9 @@ class _CalendarWidgetState extends ConsumerState<CalendarWidget> {
       return 0;
     });
 
-    showDayEventsBottomSheet(context, date, dayEvents);
+    showDayEventsBottomSheet(context, date, dayEvents, (event) {
+      ref.read(calendarProvider.notifier).revealCreatedEvent(event);
+    });
   }
 
   @override
@@ -93,82 +96,79 @@ class _CalendarWidgetState extends ConsumerState<CalendarWidget> {
     final focusedMonth = ref.watch(
       calendarProvider.select((s) => s.focusedMonth),
     );
-    final isLoading = ref.watch(
-      calendarProvider.select((s) => s.isLoading),
-    );
+    final isLoading = ref.watch(calendarProvider.select((s) => s.isLoading));
     // 일정 추가/수정 시 즉시 반영을 위해 events watch
     ref.watch(eventsProvider);
     final calendarController = ref.read(calendarProvider.notifier);
 
     // 외부에서 월이 변경되면 페이지도 이동 (Picker에서 선택 시)
-    ref.listen(
-      calendarProvider.select((s) => s.focusedMonth),
-      (previous, next) {
-        if (previous != next) {
-          final targetPage = _getPageFromMonth(next);
-          if (_pageController.hasClients &&
-              _pageController.page?.round() != targetPage) {
-            _programmaticPageAnimationDepth++;
-            _pageController
-                .animateToPage(
-                  targetPage,
-                  duration: const Duration(milliseconds: 300),
-                  curve: Curves.easeInOut,
-                )
-                .whenComplete(() {
-              if (!mounted) return;
-              _programmaticPageAnimationDepth--;
-              if (_programmaticPageAnimationDepth < 0) {
-                _programmaticPageAnimationDepth = 0;
-              }
-            });
-          }
+    ref.listen(calendarProvider.select((s) => s.focusedMonth), (
+      previous,
+      next,
+    ) {
+      if (previous != next) {
+        final targetPage = _getPageFromMonth(next);
+        if (_pageController.hasClients &&
+            _pageController.page?.round() != targetPage) {
+          _programmaticPageAnimationDepth++;
+          _pageController
+              .animateToPage(
+                targetPage,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+              )
+              .whenComplete(() {
+                if (!mounted) return;
+                _programmaticPageAnimationDepth--;
+                if (_programmaticPageAnimationDepth < 0) {
+                  _programmaticPageAnimationDepth = 0;
+                }
+              });
         }
-      },
-    );
+      }
+    });
 
     return Stack(
       children: [
         Column(
           children: [
             CalendarHeader(
-                monthSelectorKey: _monthAnchorKey,
-                focusedMonth: focusedMonth,
-                onMonthTap: () {
-                  showCalendarYearMonthPicker(
-                    context,
-                    ref,
-                    anchorKey: _monthAnchorKey,
-                    currentMonth: focusedMonth,
-                    fallbackPanelTop:
-                        MediaQuery.paddingOf(context).top + 56 + 48,
+              monthSelectorKey: _monthAnchorKey,
+              focusedMonth: focusedMonth,
+              onMonthTap: () {
+                showCalendarYearMonthPicker(
+                  context,
+                  ref,
+                  anchorKey: _monthAnchorKey,
+                  currentMonth: focusedMonth,
+                  fallbackPanelTop: MediaQuery.paddingOf(context).top + 56 + 48,
+                );
+              },
+            ),
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                // 슬라이드 완료 후 헤더만 업데이트
+                onPageChanged: (page) {
+                  if (_programmaticPageAnimationDepth > 0) return;
+                  final newMonth = _getMonthFromPage(page);
+                  if (newMonth.year != focusedMonth.year ||
+                      newMonth.month != focusedMonth.month) {
+                    // 비동기로 상태 업데이트 (UI 블로킹 방지)
+                    Future.microtask(() {
+                      calendarController.goToMonth(newMonth);
+                    });
+                  }
+                },
+                itemBuilder: (context, index) {
+                  final month = _getMonthFromPage(index);
+                  return CalendarGrid(
+                    focusedMonth: month,
+                    onDayTap: (date) => _showDayEventsSheet(context, date),
                   );
                 },
               ),
-            Expanded(
-              child: PageView.builder(
-            controller: _pageController,
-            // 슬라이드 완료 후 헤더만 업데이트
-            onPageChanged: (page) {
-              if (_programmaticPageAnimationDepth > 0) return;
-              final newMonth = _getMonthFromPage(page);
-              if (newMonth.year != focusedMonth.year ||
-                  newMonth.month != focusedMonth.month) {
-                // 비동기로 상태 업데이트 (UI 블로킹 방지)
-                Future.microtask(() {
-                  calendarController.goToMonth(newMonth);
-                });
-              }
-            },
-            itemBuilder: (context, index) {
-              final month = _getMonthFromPage(index);
-              return CalendarGrid(
-                focusedMonth: month,
-                onDayTap: (date) => _showDayEventsSheet(context, date),
-              );
-            },
-          ),
-        ),
+            ),
           ],
         ),
         if (isLoading)

--- a/lib/views/widgets/calendar/day_events_bottom_sheet.dart
+++ b/lib/views/widgets/calendar/day_events_bottom_sheet.dart
@@ -21,6 +21,7 @@ void showDayEventsBottomSheet(
   BuildContext context,
   DateTime date,
   List<CalendarEvent> events,
+  ValueChanged<CalendarEvent>? onEventCreated,
 ) {
   showModalBottomSheet(
     context: context,
@@ -29,7 +30,11 @@ void showDayEventsBottomSheet(
     enableDrag: true,
     useSafeArea: true,
     backgroundColor: Colors.transparent,
-    builder: (context) => DayEventsBottomSheet(date: date, events: events),
+    builder: (context) => DayEventsBottomSheet(
+      date: date,
+      events: events,
+      onEventCreated: onEventCreated,
+    ),
   );
 }
 
@@ -39,10 +44,12 @@ class DayEventsBottomSheet extends ConsumerStatefulWidget {
     super.key,
     required this.date,
     required this.events,
+    this.onEventCreated,
   });
 
   final DateTime date;
   final List<CalendarEvent> events;
+  final ValueChanged<CalendarEvent>? onEventCreated;
 
   @override
   ConsumerState<DayEventsBottomSheet> createState() =>
@@ -123,15 +130,22 @@ class _DayEventsBottomSheetState extends ConsumerState<DayEventsBottomSheet> {
     );
   }
 
-  void _navigateToEventForm() {
+  Future<void> _navigateToEventForm() async {
     // 바텀시트 닫고 일정 추가 화면으로 이동 (선택한 날짜 전달)
     final selectedDate = widget.date;
-    Navigator.of(context).pop();
-    Navigator.of(context).push(
+    final navigator = Navigator.of(context);
+    final onEventCreated = widget.onEventCreated;
+
+    navigator.pop();
+    final result = await navigator.push(
       MaterialPageRoute(
         builder: (_) => EventFormScreen(initialDate: selectedDate),
       ),
     );
+
+    if (result != null && result.isCreate == true) {
+      onEventCreated?.call(result.event);
+    }
   }
 
   /// 드래그 핸들 + 날짜 헤더 (통합)
@@ -169,10 +183,7 @@ class _DayEventsBottomSheetState extends ConsumerState<DayEventsBottomSheet> {
               const SizedBox(width: 8),
               Text(
                 lunarDate,
-                style: const TextStyle(
-                  fontSize: 14,
-                  color: AppColors.gray600,
-                ),
+                style: const TextStyle(fontSize: 14, color: AppColors.gray600),
               ),
             ],
           ),
@@ -255,18 +266,11 @@ class _DayEventsBottomSheetState extends ConsumerState<DayEventsBottomSheet> {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(
-            Icons.event_note_outlined,
-            size: 64,
-            color: AppColors.gray400,
-          ),
+          Icon(Icons.event_note_outlined, size: 64, color: AppColors.gray400),
           const SizedBox(height: 16),
           Text(
             '일정이 없습니다',
-            style: const TextStyle(
-              fontSize: 16,
-              color: AppColors.gray600,
-            ),
+            style: const TextStyle(fontSize: 16, color: AppColors.gray600),
           ),
         ],
       ),
@@ -278,5 +282,4 @@ class _DayEventsBottomSheetState extends ConsumerState<DayEventsBottomSheet> {
     const weekdays = ['월', '화', '수', '목', '금', '토', '일'];
     return weekdays[weekday - 1];
   }
-
 }

--- a/lib/views/widgets/event/event_time_section.dart
+++ b/lib/views/widgets/event/event_time_section.dart
@@ -51,7 +51,11 @@ class _EventTimeSectionState extends State<EventTimeSection> {
   @override
   void initState() {
     super.initState();
-    _displayedMonth = DateTime(widget.startDate.year, widget.startDate.month, 1);
+    _displayedMonth = DateTime(
+      widget.startDate.year,
+      widget.startDate.month,
+      1,
+    );
   }
 
   @override
@@ -63,7 +67,11 @@ class _EventTimeSectionState extends State<EventTimeSection> {
     }
 
     if (_activeTarget == null) {
-      _displayedMonth = DateTime(widget.startDate.year, widget.startDate.month, 1);
+      _displayedMonth = DateTime(
+        widget.startDate.year,
+        widget.startDate.month,
+        1,
+      );
     }
   }
 
@@ -78,66 +86,70 @@ class _EventTimeSectionState extends State<EventTimeSection> {
         (_activeTarget == _InlinePickerTarget.endDate ||
             _activeTarget == _InlinePickerTarget.endTime);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            const Text(
-              '시간 설정',
-              style: TextStyle(
-                color: AppColors.gray900,
-                fontSize: 16,
-                fontWeight: FontWeight.w500,
+    return TapRegion(
+      enabled: _activeTarget != null,
+      onTapOutside: (_) => _closeInlinePicker(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                '시간 설정',
+                style: TextStyle(
+                  color: AppColors.gray900,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
-            ),
-            if (widget.isEditable)
-              CustomToggle(
-                value: widget.timeSetting,
-                onChanged: widget.onTimeSettingChanged,
-              ),
+              if (widget.isEditable)
+                CustomToggle(
+                  value: widget.timeSetting,
+                  onChanged: widget.onTimeSettingChanged,
+                ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          EventTimeRow(
+            label: '시작',
+            date: widget.startDate,
+            time: widget.showTime ? widget.startTime : null,
+            showTimeChip: widget.showTime,
+            isEditable: widget.isEditable,
+            onDateTap: () => _onDateChipTap(_InlinePickerTarget.startDate),
+            onTimeTap: widget.showTime
+                ? () => _onTimeChipTap(_InlinePickerTarget.startTime)
+                : null,
+            isDateActive: _activeTarget == _InlinePickerTarget.startDate,
+            isTimeActive: _activeTarget == _InlinePickerTarget.startTime,
+          ),
+          if (showStartPicker) ...[
+            const SizedBox(height: 16),
+            _buildWiderInlinePicker(),
+            const SizedBox(height: 12),
+          ] else
+            const SizedBox(height: 12),
+          EventTimeRow(
+            label: '종료',
+            date: widget.endDate,
+            time: widget.showTime ? widget.endTime : null,
+            showTimeChip: widget.showTime,
+            isEditable: widget.isEditable,
+            onDateTap: () => _onDateChipTap(_InlinePickerTarget.endDate),
+            onTimeTap: widget.showTime
+                ? () => _onTimeChipTap(_InlinePickerTarget.endTime)
+                : null,
+            isDateActive: _activeTarget == _InlinePickerTarget.endDate,
+            isTimeActive: _activeTarget == _InlinePickerTarget.endTime,
+          ),
+          if (showEndPicker) ...[
+            const SizedBox(height: 16),
+            _buildWiderInlinePicker(),
           ],
-        ),
-        const SizedBox(height: 16),
-        EventTimeRow(
-          label: '시작',
-          date: widget.startDate,
-          time: widget.showTime ? widget.startTime : null,
-          showTimeChip: widget.showTime,
-          isEditable: widget.isEditable,
-          onDateTap: () => _onDateChipTap(_InlinePickerTarget.startDate),
-          onTimeTap: widget.showTime
-              ? () => _onTimeChipTap(_InlinePickerTarget.startTime)
-              : null,
-          isDateActive: _activeTarget == _InlinePickerTarget.startDate,
-          isTimeActive: _activeTarget == _InlinePickerTarget.startTime,
-        ),
-        if (showStartPicker) ...[
-          const SizedBox(height: 16),
-          _buildWiderInlinePicker(),
-          const SizedBox(height: 12),
-        ] else
-          const SizedBox(height: 12),
-        EventTimeRow(
-          label: '종료',
-          date: widget.endDate,
-          time: widget.showTime ? widget.endTime : null,
-          showTimeChip: widget.showTime,
-          isEditable: widget.isEditable,
-          onDateTap: () => _onDateChipTap(_InlinePickerTarget.endDate),
-          onTimeTap: widget.showTime
-              ? () => _onTimeChipTap(_InlinePickerTarget.endTime)
-              : null,
-          isDateActive: _activeTarget == _InlinePickerTarget.endDate,
-          isTimeActive: _activeTarget == _InlinePickerTarget.endTime,
-        ),
-        if (showEndPicker) ...[
-          const SizedBox(height: 16),
-          _buildWiderInlinePicker(),
         ],
-      ],
+      ),
     );
   }
 
@@ -284,11 +296,11 @@ class _EventTimeSectionState extends State<EventTimeSection> {
                     itemCount: days.length,
                     gridDelegate:
                         const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 7,
-                      mainAxisSpacing: 8,
-                      crossAxisSpacing: 4,
-                      childAspectRatio: 1,
-                    ),
+                          crossAxisCount: 7,
+                          mainAxisSpacing: 8,
+                          crossAxisSpacing: 4,
+                          childAspectRatio: 1,
+                        ),
                     itemBuilder: (context, index) {
                       final day = days[index];
                       final isSelected = _isSameDay(day.date, selectedDate);
@@ -309,11 +321,13 @@ class _EventTimeSectionState extends State<EventTimeSection> {
                               color: isSelected
                                   ? AppColors.surface
                                   : (day.isCurrentMonth
-                                      ? AppColors.gray900
-                                      : AppColors.gray400),
+                                        ? AppColors.gray900
+                                        : AppColors.gray400),
                               fontWeight: isSelected
                                   ? FontWeight.w700
-                                  : (isToday ? FontWeight.w700 : FontWeight.w500),
+                                  : (isToday
+                                        ? FontWeight.w700
+                                        : FontWeight.w500),
                               decoration: isToday && !isSelected
                                   ? TextDecoration.underline
                                   : TextDecoration.none,
@@ -447,6 +461,17 @@ class _EventTimeSectionState extends State<EventTimeSection> {
 
     setState(() {
       _displayedMonth = DateTime(normalized.year, normalized.month, 1);
+      _activeTarget = null;
+      _showMonthYearPicker = false;
+    });
+  }
+
+  void _closeInlinePicker() {
+    if (_activeTarget == null) return;
+
+    setState(() {
+      _activeTarget = null;
+      _showMonthYearPicker = false;
     });
   }
 
@@ -480,20 +505,7 @@ class _InlineTimeWheelPicker extends StatefulWidget {
 
 class _InlineTimeWheelPickerState extends State<_InlineTimeWheelPicker> {
   static const _itemExtent = 46.0;
-  static const _minutes = [
-    0,
-    5,
-    10,
-    15,
-    20,
-    25,
-    30,
-    35,
-    40,
-    45,
-    50,
-    55,
-  ];
+  static const _minutes = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55];
   static const _periods = ['오전', '오후'];
 
   late int _periodIndex;
@@ -600,7 +612,8 @@ class _InlineTimeWheelPickerState extends State<_InlineTimeWheelPicker> {
             child: _buildWheel(
               controller: _minuteController,
               itemCount: _minutes.length,
-              labelBuilder: (index) => _minutes[index].toString().padLeft(2, '0'),
+              labelBuilder: (index) =>
+                  _minutes[index].toString().padLeft(2, '0'),
               onSelectedItemChanged: (index) {
                 setState(() {
                   _minuteIndex = index;
@@ -816,10 +829,7 @@ class _MonthYearWheelPickerState extends State<_MonthYearWheelPicker> {
 enum _InlinePickerTarget { startDate, startTime, endDate, endTime }
 
 class _CalendarCell {
-  _CalendarCell({
-    required this.date,
-    required this.isCurrentMonth,
-  });
+  _CalendarCell({required this.date, required this.isCurrentMonth});
 
   final DateTime date;
   final bool isCurrentMonth;

--- a/lib/views/widgets/home/folder_section.dart
+++ b/lib/views/widgets/home/folder_section.dart
@@ -78,7 +78,7 @@ class FolderSection extends ConsumerWidget {
                       if (context.mounted) {
                         showAppSnackBar(
                           context,
-                          '보관함은 최대 20개까지 생성할 수 있습니다.',
+                          HomeController.folderLimitMessage,
                         );
                       }
                       return;

--- a/test/calendar_event_index_test.dart
+++ b/test/calendar_event_index_test.dart
@@ -30,11 +30,25 @@ void main() {
   });
 
   group('CalendarEventIndex.build', () {
+    test('월 경계의 이전 달과 다음 달 일정도 셀에 표시한다', () {
+      final focusedMonth = DateTime.parse('2026-07-01');
+      final days = CalendarUtils.getDaysInMonth(focusedMonth);
+      final events = [
+        _event(id: 'previous', startAt: '2026-06-30', endAt: '2026-06-30'),
+        _event(id: 'next', startAt: '2026-08-01', endAt: '2026-08-01'),
+      ];
+
+      final index = CalendarEventIndex.build(focusedMonth, events);
+
+      expect(days.first, DateTime(2026, 6, 28));
+      expect(index.getEventsForDay(DateTime(2026, 6, 30)), [events.first]);
+      expect(index.getEventsForDay(DateTime(2026, 8, 1)), [events.last]);
+    });
+
     test('월요일에 끝난 슬롯 2를 화요일 일정이 재사용한다', () {
       // 2025-06-08(일) ~ 2025-06-15(일) 주
       const month = '2025-06-01';
       final focusedMonth = DateTime.parse(month);
-      final days = CalendarUtils.getDaysInMonth(focusedMonth);
       final weekStart = DateTime.parse('2025-06-08');
       const tuesdayCol = 2;
 
@@ -147,6 +161,3 @@ void main() {
     });
   });
 }
-
-String _dateKey(DateTime date) =>
-    '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';


### PR DESCRIPTION
- CalendarController에 캐시 및 프리패치 로직을 추가하여 일정 로드 성능 개선
- 생성된 이벤트를 즉시 캘린더에 반영하는 revealCreatedEvent 메서드 구현
- 인접 월의 이벤트를 미리 로드하는 _prefetchAdjacentMonths 메서드 추가
- 캐시 만료 및 갱신 로직을 포함한 _CalendarCacheEntry 클래스 추가
- 홈 화면 및 캘린더 위젯에서 이벤트 생성 시 캘린더 업데이트 반영