### PR TITLE
feat: 공유 항목 처리 로직 개선 및 링크 생성 기능 추가

### DIFF
--- a/android/app/src/main/kotlin/com/toit/android/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/toit/android/MainActivity.kt
@@ -32,6 +32,7 @@ class MainActivity : FlutterActivity() {
       action == Intent.ACTION_SEND_MULTIPLE
     if (!isSendAction) return false
 
-    return targetIntent.hasExtra(Intent.EXTRA_STREAM)
+    return targetIntent.hasExtra(Intent.EXTRA_STREAM) ||
+      targetIntent.hasExtra(Intent.EXTRA_TEXT)
   }
 }

--- a/ios/Share Extension/Info.plist
+++ b/ios/Share Extension/Info.plist
@@ -10,8 +10,16 @@
 		<dict>
 			<key>NSExtensionActivationRule</key>
 			<dict>
+				<key>NSExtensionActivationSupportsFileWithMaxCount</key>
+				<integer>10</integer>
 				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
 				<integer>30</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
 			</dict>
 			<key>PHSupportedMediaTypes</key>
 			<array>

--- a/ios/Share Extension/ShareApiClient.swift
+++ b/ios/Share Extension/ShareApiClient.swift
@@ -136,6 +136,39 @@ final class ShareApiClient {
     )
   }
 
+  // MARK: - Create Link
+
+  func createLink(
+    linksUrl: String,
+    folderId: Int,
+    textContent: String
+  ) async throws {
+    let url = URL(string: "\(baseUrl)/links")!
+    var req = URLRequest(url: url)
+    req.httpMethod = "POST"
+    req.setValue(
+      "Bearer \(accessToken)",
+      forHTTPHeaderField: "Authorization"
+    )
+    req.setValue(
+      "application/json",
+      forHTTPHeaderField: "Content-Type"
+    )
+    req.timeoutInterval = 15
+
+    var body: [String: Any] = [
+      "foldersIdList": [folderId],
+      "linksUrl": linksUrl,
+    ]
+    if !textContent.isEmpty {
+      body["textContent"] = textContent
+    }
+    req.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+    let (_, response) = try await URLSession.shared.data(for: req)
+    try validateResponse(response)
+  }
+
   // MARK: - Private Helpers
 
   private func request(

--- a/ios/Share Extension/ShareViewController.swift
+++ b/ios/Share Extension/ShareViewController.swift
@@ -2,6 +2,11 @@ import UIKit
 import UniformTypeIdentifiers
 
 final class ShareViewController: UIViewController {
+  private enum SharedItem {
+    case attachment(url: URL, isImage: Bool)
+    case link(String)
+  }
+
   private enum Constants {
     static let maxMemoLength = 1000
     static let maxImageSaveCount = 3
@@ -19,8 +24,7 @@ final class ShareViewController: UIViewController {
   private var allFolders: [ShareFolder] = []
   private var displayedFolders: [ShareFolder] = []
   private var selectedFolder: ShareFolder?
-  private var sharedItemUrls: [URL] = []
-  private var isImage = true
+  private var sharedItems: [SharedItem] = []
   private var isSaving = false
   private var bottomSpacerHeightConstraint: NSLayoutConstraint?
 
@@ -290,30 +294,115 @@ final class ShareViewController: UIViewController {
       if provider.hasItemConformingToTypeIdentifier(
         UTType.image.identifier
       ) {
-        isImage = true
         group.enter()
         provider.loadItem(
           forTypeIdentifier: UTType.image.identifier
         ) { [weak self] item, _ in
           defer { group.leave() }
           if let url = item as? URL {
-            self?.sharedItemUrls.append(url)
+            self?.appendSharedItem(
+              .attachment(url: url, isImage: true)
+            )
+          }
+        }
+      } else if provider.hasItemConformingToTypeIdentifier(
+        UTType.url.identifier
+      ) {
+        group.enter()
+        provider.loadItem(
+          forTypeIdentifier: UTType.url.identifier
+        ) { [weak self] item, _ in
+          defer { group.leave() }
+          if let link = self?.linkString(from: item) {
+            self?.appendSharedItem(.link(link))
+          }
+        }
+      } else if provider.hasItemConformingToTypeIdentifier(
+        UTType.plainText.identifier
+      ) {
+        group.enter()
+        provider.loadItem(
+          forTypeIdentifier: UTType.plainText.identifier
+        ) { [weak self] item, _ in
+          defer { group.leave() }
+          if let link = self?.linkString(from: item) {
+            self?.appendSharedItem(.link(link))
           }
         }
       } else if provider.hasItemConformingToTypeIdentifier(
         UTType.data.identifier
       ) {
-        isImage = false
         group.enter()
-        provider.loadItem(
+        provider.loadFileRepresentation(
           forTypeIdentifier: UTType.data.identifier
-        ) { [weak self] item, _ in
+        ) { [weak self] url, _ in
           defer { group.leave() }
-          if let url = item as? URL {
-            self?.sharedItemUrls.append(url)
+          guard let self, let url else { return }
+          if let copiedUrl = self.copySharedFileToTemporaryDirectory(url) {
+            self.appendSharedItem(
+              .attachment(url: copiedUrl, isImage: false)
+            )
           }
         }
       }
+    }
+  }
+
+  private func appendSharedItem(_ item: SharedItem) {
+    DispatchQueue.main.async {
+      self.sharedItems.append(item)
+    }
+  }
+
+  private func linkString(from item: Any?) -> String? {
+    if let url = item as? URL {
+      return url.absoluteString
+    }
+    guard let text = item as? String else { return nil }
+    let trimmed = text.trimmingCharacters(
+      in: .whitespacesAndNewlines
+    )
+    if URL(string: trimmed)?.scheme != nil {
+      return trimmed
+    }
+    return firstLink(in: trimmed)
+  }
+
+  private func firstLink(in text: String) -> String? {
+    guard
+      let detector = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.link.rawValue
+      )
+    else { return nil }
+    let range = NSRange(text.startIndex..<text.endIndex, in: text)
+    return detector.firstMatch(
+      in: text,
+      options: [],
+      range: range
+    )?.url?.absoluteString
+  }
+
+  private func copySharedFileToTemporaryDirectory(_ sourceUrl: URL) -> URL? {
+    let fileManager = FileManager.default
+    let fileName = sourceUrl.lastPathComponent.isEmpty
+      ? UUID().uuidString
+      : sourceUrl.lastPathComponent
+    let destination = fileManager.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathComponent(fileName)
+
+    do {
+      try fileManager.createDirectory(
+        at: destination.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      if fileManager.fileExists(atPath: destination.path) {
+        try fileManager.removeItem(at: destination)
+      }
+      try fileManager.copyItem(at: sourceUrl, to: destination)
+      return destination
+    } catch {
+      return nil
     }
   }
 
@@ -568,8 +657,8 @@ final class ShareViewController: UIViewController {
       showError("보관함을 선택해주세요.")
       return
     }
-    guard !sharedItemUrls.isEmpty else {
-      showError("공유된 파일이 없습니다.")
+    guard !sharedItems.isEmpty else {
+      showError("공유된 항목이 없습니다.")
       return
     }
     if uploadValidationFails() {
@@ -582,26 +671,33 @@ final class ShareViewController: UIViewController {
     loadingIndicator.startAnimating()
 
     let memo = memoTextView.text ?? ""
-    let urls = sharedItemUrls
-    let uploadAsImage = isImage
+    let items = sharedItems
 
     Task {
       do {
-        for url in urls {
-          let data = try Data(contentsOf: url)
-          let fileName = url.lastPathComponent
-
-          if uploadAsImage {
-            try await client.uploadImage(
-              data: data,
-              fileName: fileName,
-              folderId: folder.foldersId,
-              textContent: memo
-            )
-          } else {
-            try await client.uploadFile(
-              data: data,
-              fileName: fileName,
+        for item in items {
+          switch item {
+          case .attachment(let url, let isImage):
+            let data = try Data(contentsOf: url)
+            let fileName = url.lastPathComponent
+            if isImage {
+              try await client.uploadImage(
+                data: data,
+                fileName: fileName,
+                folderId: folder.foldersId,
+                textContent: memo
+              )
+            } else {
+              try await client.uploadFile(
+                data: data,
+                fileName: fileName,
+                folderId: folder.foldersId,
+                textContent: memo
+              )
+            }
+          case .link(let link):
+            try await client.createLink(
+              linksUrl: link,
               folderId: folder.foldersId,
               textContent: memo
             )
@@ -715,14 +811,20 @@ final class ShareViewController: UIViewController {
   // MARK: - Error
 
   private func uploadValidationFails() -> Bool {
-    if isImage && sharedItemUrls.count > Constants.maxImageSaveCount {
+    let imageCount = sharedItems.reduce(0) { count, item in
+      if case .attachment(_, let isImage) = item, isImage {
+        return count + 1
+      }
+      return count
+    }
+    if imageCount > Constants.maxImageSaveCount {
       showAlert(
         "이미지는 3개 이상 저장할 수 없습니다."
       )
       return true
     }
-    if !isImage {
-      for url in sharedItemUrls {
+    for item in sharedItems {
+      if case .attachment(let url, let isImage) = item, !isImage {
         guard let fileSize = fileSizeBytes(
           for: url
         ) else { continue }

--- a/lib/views/screens/navigation_shell.dart
+++ b/lib/views/screens/navigation_shell.dart
@@ -107,12 +107,12 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
   Future<void> _handleSharedMedia(List<SharedMediaFile> mediaFiles) async {
     if (!mounted || _isShareSheetVisible || mediaFiles.isEmpty) return;
 
-    final sharedAttachments = mediaFiles
-        .map((file) => _toSharedAttachment(file.path))
-        .whereType<_SharedAttachment>()
+    final sharedItems = mediaFiles
+        .map(_toSharedItem)
+        .whereType<_SharedItem>()
         .toList();
 
-    if (sharedAttachments.isEmpty) return;
+    if (sharedItems.isEmpty) return;
 
     _isShareSheetVisible = true;
     try {
@@ -120,7 +120,7 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
       if (!mounted) return;
 
       if (folders.isEmpty) {
-        _showSnackBar('보관함이 없어 공유 이미지를 저장할 수 없습니다.');
+        _showSnackBar('보관함이 없어 공유 항목을 저장할 수 없습니다.');
         return;
       }
 
@@ -129,12 +129,13 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
         folders: folders,
         initialSelectedFolder: folders.where((f) => f.isDefault).firstOrNull,
         onSave: (selectedFolder, memo) async {
-          await _saveSharedAttachments(
-            attachments: sharedAttachments,
+          await _saveSharedItems(
+            items: sharedItems,
             selectedFolder: selectedFolder,
             memo: memo,
           );
         },
+        errorMessageBuilder: _sharedSaveErrorMessage,
       );
     } finally {
       _isShareSheetVisible = false;
@@ -151,97 +152,150 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
     return state.folders;
   }
 
-  Future<void> _saveSharedAttachments({
-    required List<_SharedAttachment> attachments,
+  Future<void> _saveSharedItems({
+    required List<_SharedItem> items,
     required FolderItem selectedFolder,
     required String memo,
   }) async {
     final repository = ref.read(homeRepositoryProvider);
-    int savedCount = 0;
-    String? failReason;
 
-    for (final attachment in attachments) {
-      final file = File(attachment.path);
-      if (!await file.exists()) {
-        failReason = '공유된 파일을 찾을 수 없습니다.';
-        continue;
-      }
-
-      List<int> fileBytes;
-      try {
-        fileBytes = await file.readAsBytes();
-      } catch (_) {
-        failReason = '공유된 파일을 읽을 수 없습니다.';
-        continue;
-      }
-      if (fileBytes.isEmpty) {
-        failReason = '공유된 파일을 읽을 수 없습니다.';
-        continue;
-      }
-
-      final fileName = _extractFileName(attachment.path);
-      final validateMessage = attachment.isImage
-          ? validateImageSectionUpload(
-              fileName: fileName,
-              fileSizeBytes: fileBytes.length,
-            )
-          : validateFileSectionUpload(
-              fileName: fileName,
-              fileSizeBytes: fileBytes.length,
-            );
-      if (validateMessage != null) {
-        failReason = validateMessage;
-        continue;
-      }
-
-      try {
-        if (attachment.isImage) {
-          await repository.createImage(
-            foldersIdList: [selectedFolder.foldersId],
-            textContent: memo,
-            imageBytes: fileBytes,
-            fileName: fileName,
-          );
-        } else {
-          await repository.createFile(
-            foldersIdList: [selectedFolder.foldersId],
-            textContent: memo,
-            fileBytes: fileBytes,
-            fileName: fileName,
-          );
-        }
-        savedCount++;
-      } on DioException catch (e) {
-        if (e.response?.statusCode == 401) {
-          failReason = '인증이 만료되었습니다. 앱에서 다시 로그인해주세요.';
-        } else {
-          failReason = '공유 항목 저장 중 오류가 발생했습니다.';
-        }
-      } catch (_) {
-        failReason = '공유 항목 저장에 실패했습니다.';
-      }
-    }
-
-    if (savedCount <= 0) {
-      _showSnackBar(failReason ?? '공유 항목 저장에 실패했습니다.');
-      throw Exception('Failed to save shared attachments.');
+    for (final item in items) {
+      await _saveSharedItem(
+        repository: repository,
+        item: item,
+        selectedFolder: selectedFolder,
+        memo: memo,
+      );
     }
 
     await ref.read(homeProvider.notifier).refresh();
     ref.invalidate(pageItemsProvider(selectedFolder.foldersId));
-    _showSnackBar(
-      savedCount == attachments.length
-          ? '공유 항목이 저장되었습니다.'
-          : '$savedCount개 저장됨. 일부 실패.',
-    );
+    _showSnackBar('공유 항목이 저장되었습니다.');
   }
 
-  _SharedAttachment? _toSharedAttachment(String rawPath) {
-    final normalizedPath = _normalizeFilePath(rawPath);
+  Future<void> _saveSharedItem({
+    required HomeRepository repository,
+    required _SharedItem item,
+    required FolderItem selectedFolder,
+    required String memo,
+  }) async {
+    switch (item.type) {
+      case _SharedItemType.link:
+        await repository.createLink(
+          foldersIdList: [selectedFolder.foldersId],
+          linksUrl: item.value,
+          textContent: memo,
+        );
+      case _SharedItemType.note:
+        await repository.createText(
+          foldersIdList: [selectedFolder.foldersId],
+          textContent: _mergeSharedTextAndMemo(
+            sharedText: item.value,
+            memo: memo,
+          ),
+        );
+      case _SharedItemType.attachment:
+        await _saveSharedAttachment(
+          repository: repository,
+          item: item,
+          selectedFolder: selectedFolder,
+          memo: memo,
+        );
+    }
+  }
+
+  Future<void> _saveSharedAttachment({
+    required HomeRepository repository,
+    required _SharedItem item,
+    required FolderItem selectedFolder,
+    required String memo,
+  }) async {
+    final fileBytes = await _readSharedFileBytes(item.value);
+    final fileName = _extractFileName(item.value);
+    final validateMessage = item.isImage
+        ? validateImageSectionUpload(
+            fileName: fileName,
+            fileSizeBytes: fileBytes.length,
+          )
+        : validateFileSectionUpload(
+            fileName: fileName,
+            fileSizeBytes: fileBytes.length,
+          );
+    if (validateMessage != null) {
+      throw _SharedSaveException(validateMessage);
+    }
+
+    if (item.isImage) {
+      await repository.createImage(
+        foldersIdList: [selectedFolder.foldersId],
+        textContent: memo,
+        imageBytes: fileBytes,
+        fileName: fileName,
+      );
+    } else {
+      await repository.createFile(
+        foldersIdList: [selectedFolder.foldersId],
+        textContent: memo,
+        fileBytes: fileBytes,
+        fileName: fileName,
+      );
+    }
+  }
+
+  Future<List<int>> _readSharedFileBytes(String path) async {
+    final file = File(path);
+    if (!await file.exists()) {
+      throw const _SharedSaveException('공유된 파일을 찾을 수 없습니다.');
+    }
+
+    final fileBytes = await file.readAsBytes();
+    if (fileBytes.isEmpty) {
+      throw const _SharedSaveException('공유된 파일을 읽을 수 없습니다.');
+    }
+    return fileBytes;
+  }
+
+  String _sharedSaveErrorMessage(Object error) {
+    if (error is _SharedSaveException) {
+      return error.message;
+    }
+    if (error is DioException) {
+      return _sharedSaveDioErrorMessage(error);
+    }
+    return '공유 항목 저장에 실패했습니다.';
+  }
+
+  String _sharedSaveDioErrorMessage(DioException error) {
+    if (error.response?.statusCode == 401) {
+      return '인증이 만료되었습니다. 앱에서 다시 로그인해주세요.';
+    }
+    return '공유 항목 저장 중 오류가 발생했습니다.';
+  }
+
+  _SharedItem? _toSharedItem(SharedMediaFile mediaFile) {
+    final rawValue = mediaFile.path.trim();
+    if (rawValue.isEmpty) return null;
+
+    final sharedLink = _extractSharedLink(rawValue);
+    if (mediaFile.type == SharedMediaType.url ||
+        mediaFile.type == SharedMediaType.text) {
+      if (sharedLink != null) {
+        return _SharedItem.link(sharedLink);
+      }
+      return _SharedItem.note(rawValue);
+    }
+
+    if (sharedLink != null && _looksLikeUrlOnly(rawValue)) {
+      return _SharedItem.link(sharedLink);
+    }
+
+    final normalizedPath = _normalizeFilePath(rawValue);
     if (normalizedPath.trim().isEmpty) return null;
-    return _SharedAttachment(
+    return _SharedItem.attachment(
       path: normalizedPath,
-      isImage: _isImagePath(normalizedPath),
+      isImage:
+          mediaFile.type == SharedMediaType.image ||
+          _isImagePath(normalizedPath),
     );
   }
 
@@ -269,6 +323,34 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
     return parts.isEmpty ? 'shared_image.jpg' : parts.last;
   }
 
+  String? _extractSharedLink(String text) {
+    final trimmed = text.trim();
+    final uri = Uri.tryParse(trimmed);
+    if (uri != null && uri.hasScheme && uri.host.isNotEmpty) {
+      return trimmed;
+    }
+
+    final match = RegExp(r'https?://[^\s]+').firstMatch(trimmed);
+    return match?.group(0);
+  }
+
+  bool _looksLikeUrlOnly(String text) {
+    final trimmed = text.trim();
+    final link = _extractSharedLink(trimmed);
+    return link != null && link == trimmed;
+  }
+
+  String _mergeSharedTextAndMemo({
+    required String sharedText,
+    required String memo,
+  }) {
+    final trimmedText = sharedText.trim();
+    final trimmedMemo = memo.trim();
+    if (trimmedMemo.isEmpty) return trimmedText;
+    if (trimmedText.isEmpty) return trimmedMemo;
+    return '$trimmedText\n\n$trimmedMemo';
+  }
+
   void _showSnackBar(String message) {
     if (!mounted) return;
     showAppSnackBar(context, message);
@@ -290,9 +372,7 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
   /// 저장 화면을 띄우고, 저장된 보관함이 반환되면 해당 탭으로 이동시킨다.
   void _pushSaveScreen(Widget screen, FolderTab tab) {
     Navigator.of(context)
-        .push(
-          CupertinoPageRoute<FolderItem?>(builder: (_) => screen),
-        )
+        .push(CupertinoPageRoute<FolderItem?>(builder: (_) => screen))
         .then((savedFolder) {
           if (savedFolder == null || !mounted) return;
           _openFolderTab(savedFolder, tab);
@@ -324,9 +404,7 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
             ),
           ),
           // 업로드 배너는 네비바 위로 떠야 하므로 bottomInset으로 비켜 둔다.
-          const Positioned.fill(
-            child: UploadProgressBanner(bottomInset: 84),
-          ),
+          const Positioned.fill(child: UploadProgressBanner(bottomInset: 84)),
           // Stack에 non-positioned Align만 두면 기본 topStart에 붙어
           // '하단'이 아닌 화면 위쪽에 뜬다. 반드시 bottom 고정.
           Positioned(
@@ -344,28 +422,16 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
               onAddMenuTap: (menuIndex) {
                 switch (menuIndex) {
                   case 0:
-                    _pushSaveScreen(
-                      const SaveLinkScreen(),
-                      FolderTab.links,
-                    );
+                    _pushSaveScreen(const SaveLinkScreen(), FolderTab.links);
                     break;
                   case 1:
-                    _pushSaveScreen(
-                      const SaveNoteScreen(),
-                      FolderTab.notes,
-                    );
+                    _pushSaveScreen(const SaveNoteScreen(), FolderTab.notes);
                     break;
                   case 2:
-                    _pushSaveScreen(
-                      const SaveFileScreen(),
-                      FolderTab.files,
-                    );
+                    _pushSaveScreen(const SaveFileScreen(), FolderTab.files);
                     break;
                   case 3:
-                    _pushSaveScreen(
-                      const SaveImageScreen(),
-                      FolderTab.images,
-                    );
+                    _pushSaveScreen(const SaveImageScreen(), FolderTab.images);
                     break;
                   case 4:
                     Navigator.of(context)
@@ -381,7 +447,8 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
                                   .read(calendarProvider.notifier)
                                   .revealCreatedEvent(result.event);
                             }
-                            ref.read(currentTabIndexProvider.notifier).state = 1;
+                            ref.read(currentTabIndexProvider.notifier).state =
+                                1;
                           }
                         });
                     break;
@@ -395,9 +462,31 @@ class _NavigationShellState extends ConsumerState<NavigationShell> {
   }
 }
 
-class _SharedAttachment {
-  final String path;
+enum _SharedItemType { attachment, link, note }
+
+class _SharedItem {
+  final _SharedItemType type;
+  final String value;
   final bool isImage;
 
-  const _SharedAttachment({required this.path, required this.isImage});
+  const _SharedItem._({
+    required this.type,
+    required this.value,
+    this.isImage = false,
+  });
+
+  const _SharedItem.attachment({required String path, required bool isImage})
+    : this._(type: _SharedItemType.attachment, value: path, isImage: isImage);
+
+  const _SharedItem.link(String url)
+    : this._(type: _SharedItemType.link, value: url);
+
+  const _SharedItem.note(String text)
+    : this._(type: _SharedItemType.note, value: text);
+}
+
+class _SharedSaveException implements Exception {
+  final String message;
+
+  const _SharedSaveException(this.message);
 }

--- a/lib/views/widgets/common/share_save_bottom_sheet.dart
+++ b/lib/views/widgets/common/share_save_bottom_sheet.dart
@@ -14,6 +14,7 @@ Future<void> showShareSaveBottomSheet(
   FolderItem? initialSelectedFolder,
   String initialMemo = '',
   required Future<void> Function(FolderItem selectedFolder, String memo) onSave,
+  String Function(Object error)? errorMessageBuilder,
 }) {
   return showModalBottomSheet<void>(
     context: context,
@@ -24,6 +25,7 @@ Future<void> showShareSaveBottomSheet(
       initialSelectedFolder: initialSelectedFolder,
       initialMemo: initialMemo,
       onSave: onSave,
+      errorMessageBuilder: errorMessageBuilder,
     ),
   );
 }
@@ -36,12 +38,14 @@ class ShareSaveBottomSheet extends StatefulWidget {
     this.initialSelectedFolder,
     this.initialMemo = '',
     required this.onSave,
+    this.errorMessageBuilder,
   });
 
   final List<FolderItem> folders;
   final FolderItem? initialSelectedFolder;
   final String initialMemo;
   final Future<void> Function(FolderItem selectedFolder, String memo) onSave;
+  final String Function(Object error)? errorMessageBuilder;
 
   @override
   State<ShareSaveBottomSheet> createState() => _ShareSaveBottomSheetState();
@@ -60,6 +64,7 @@ class _ShareSaveBottomSheetState extends State<ShareSaveBottomSheet> {
   String folderQuery = '';
   int memoLength = 0;
   bool isSaving = false;
+  String? errorMessage;
 
   @override
   void initState() {
@@ -90,11 +95,20 @@ class _ShareSaveBottomSheetState extends State<ShareSaveBottomSheet> {
       return;
     }
 
-    setState(() => isSaving = true);
+    setState(() {
+      isSaving = true;
+      errorMessage = null;
+    });
     try {
       await widget.onSave(targetFolder, memoController.text.trim());
       if (!mounted) return;
       Navigator.of(context).pop();
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        errorMessage =
+            widget.errorMessageBuilder?.call(error) ?? '공유 항목 저장에 실패했습니다.';
+      });
     } finally {
       if (mounted) setState(() => isSaving = false);
     }
@@ -154,28 +168,48 @@ class _ShareSaveBottomSheetState extends State<ShareSaveBottomSheet> {
                       ),
                     ),
                     GestureDetector(
-                      onTap: handleSaveTap,
+                      onTap: isSaving ? null : handleSaveTap,
                       behavior: HitTestBehavior.opaque,
-                      child: isSaving
-                          ? const SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : Text(
-                              '저장',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w600,
-                                color: selectedFolder == null
-                                    ? AppColors.neutral100
-                                    : AppColors.blue500,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
+                        child: isSaving
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : Text(
+                                '저장',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                  color: selectedFolder == null
+                                      ? AppColors.neutral100
+                                      : AppColors.blue500,
+                                ),
                               ),
-                            ),
+                      ),
                     ),
                   ],
                 ),
                 const SizedBox(height: 18),
+                if (errorMessage != null) ...[
+                  Text(
+                    errorMessage!,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w500,
+                      color: Colors.redAccent,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                ],
                 _buildFolderSearchBar(),
                 const SizedBox(height: 12),
                 _buildFolderChips(),


### PR DESCRIPTION
- MainActivity에서 텍스트 공유 지원 추가
- Share Extension의 Info.plist에 파일 및 텍스트 공유 최대 수량 설정 추가
- ShareApiClient에 링크 생성 메서드 추가
- ShareViewController에서 공유 항목 처리 로직을 개선하여 링크 및 파일 첨부 지원
- navigation_shell.dart에서 공유 항목 처리 방식 변경
- share_save_bottom_sheet.dart에서 오류 메시지 처리 로직 개선