### PR TITLE
feat(fcm): FCM 푸시 및 일정 알림 설정 재활성화

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -197,32 +197,32 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   DKImagePickerController: 946cec48c7873164274ecc4624d19e3da4c1ef3c
   DKPhotoGallery: b3834fecb755ee09a593d7c9e389d8b5d6deed60
-  file_picker: a0560bc09d61de87f12d246fc47d2119e6ef37be
+  file_picker: b159e0c068aef54932bb15dc9fd1571818edaf49
   Firebase: 9a58fdbc9d8655ed7b79a19cf9690bb007d3d46d
-  firebase_core: ee30637e6744af8e0c12a6a1e8a9718506ec2398
-  firebase_messaging: 343de01a8d3e18b60df0c6d37f7174c44ae38e02
+  firebase_core: 8d5e24676350f15dd111aa59a88a1ae26605f9ba
+  firebase_messaging: 834cfc0887393d3108cdb19da8e57655c54fd0e4
   FirebaseCore: 0dbad74bda10b8fb9ca34ad8f375fb9dd3ebef7c
   FirebaseCoreInternal: fe5fa466aeb314787093a7dce9f0beeaad5a2a21
   FirebaseInstallations: 6a14ab3d694ebd9f839c48d330da5547e9ca9dc0
   FirebaseMessaging: 7f42cfd10ec64181db4e01b305a613791c8e782c
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  flutter_web_auth_2: 646fc9df97a01c59e5eea99b237da2c6360f8439
-  gal: baecd024ebfd13c441269ca7404792a7152fde89
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  flutter_web_auth_2: 4091f1645696258ddc57849f62bef2a848fc313c
+  gal: 6a522c75909f1244732d4596d11d6a2f86ff37a5
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  image_picker_ios: 4f2f91b01abdb52842a8e277617df877e40f905b
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  pdfx: 77f4dddc48361fbb01486fa2bdee4532cbb97ef3
-  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  pdfx: 7b876b09de8b7a0bf444a4f82b439ffcff4ee1ec
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  receive_sharing_intent: 222384f00ffe7e952bbfabaa9e3967cb87e5fe00
+  receive_sharing_intent: 79c848f5b045674ad60b9fea3bafea59962ad2c1
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  sqflite_darwin: 5a7236e3b501866c1c9befc6771dfd73ffb8702d
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: d57d795ecf1b65265eb65c139068699818742a94
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -469,21 +469,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E8F4A1B22F9000010000AB04 /* Sign Flutter Native Asset Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Sign Flutter Native Asset Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"${PLATFORM_NAME}\" = \"iphoneos\" ]; then\n  framework=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/objective_c.framework\"\n  if [ -d \"$framework\" ]; then\n    if [ -n \"${EXPANDED_CODE_SIGN_IDENTITY}\" ]; then\n      /usr/bin/codesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" --timestamp=none \"$framework\"\n    else\n      echo \"warning: EXPANDED_CODE_SIGN_IDENTITY is empty; skipping objective_c.framework signing\"\n    fi\n  fi\nfi\n";
-		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -537,6 +522,21 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		E8F4A1B22F9000010000AB04 /* Sign Flutter Native Asset Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Sign Flutter Native Asset Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${PLATFORM_NAME}\" = \"iphoneos\" ]; then\n  framework=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/objective_c.framework\"\n  if [ -d \"$framework\" ]; then\n    if [ -n \"${EXPANDED_CODE_SIGN_IDENTITY}\" ]; then\n      /usr/bin/codesign --force --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" --timestamp=none \"$framework\"\n    else\n      echo \"warning: EXPANDED_CODE_SIGN_IDENTITY is empty; skipping objective_c.framework signing\"\n    fi\n  fi\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -664,12 +664,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = toIT;
@@ -681,7 +679,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT Runner Dev Profile Sangwoo";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -699,9 +696,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.RunnerTests;
@@ -725,9 +722,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.RunnerTests;
@@ -749,9 +746,9 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.RunnerTests;
@@ -886,12 +883,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = toIT;
@@ -903,7 +898,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT Runner Dev Profile Sangwoo";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -924,12 +918,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 4;
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = toIT;
@@ -941,7 +933,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT Runner Dev Profile Sangwoo";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -965,14 +956,10 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -993,7 +980,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT ShareExtension Dev Profile Sangwoo";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1022,14 +1008,10 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1049,7 +1031,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT ShareExtension Dev Profile Sangwoo";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1076,14 +1057,10 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-
 				CUSTOM_GROUP_ID = group.com.toit.ios.share;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 86MPU972PJ;
+				DEVELOPMENT_TEAM = 86MPU972PJ;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1103,7 +1080,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.toit.ios.ShareExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "toIT ShareExtension Dev Profile Sangwoo";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/constants/api_constants.dart';
 import '../core/network/api_client.dart';
 import '../services/auth_service.dart';
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import '../services/fcm_registration_service.dart';
+import '../services/fcm_registration_service.dart';
 
 /// 소셜 로그인 진행 중인 공급자. [AuthState.activeSocialLogin]에 사용한다.
 enum SocialLoginKind { kakao, apple }
@@ -95,12 +95,11 @@ class AuthController extends Notifier<AuthState> {
       if (!me.needsNickname) {
         unawaited(_authService.fetchAndSaveCloudFrontCookies());
       }
-      // TODO(FCM-비활성화): 테스트 중 임시 주석
-      // unawaited(
-      //   ref.read(fcmRegistrationServiceProvider).syncServerRegistration(
-      //         promptForPermission: true,
-      //       ),
-      // );
+      unawaited(
+        ref.read(fcmRegistrationServiceProvider).syncServerRegistration(
+              promptForPermission: true,
+            ),
+      );
     } else {
       state = const AuthState(status: AuthStatus.unauthenticated);
     }
@@ -153,15 +152,12 @@ class AuthController extends Notifier<AuthState> {
               return;
             }
             _markAuthenticatedSideEffects();
-            // TODO(FCM-비활성화): 테스트 중 임시 주석
-            // unawaited(
-            //   ref.read(fcmRegistrationServiceProvider).syncServerRegistration(
-            //         promptForPermission: true,
-            //       ),
-            // );
-            // debugPrint(
-            // '[AuthController] 로그인 성공, userId: $userId',
-            // );
+            unawaited(
+              ref.read(fcmRegistrationServiceProvider).syncServerRegistration(
+                    promptForPermission: true,
+                  ),
+            );
+            debugPrint('[AuthController] 로그인 성공, userId: ${me.userId}');
           } else {
             state = state.copyWith(
               isLoading: false,

--- a/lib/controllers/event_form_controller.dart
+++ b/lib/controllers/event_form_controller.dart
@@ -35,9 +35,8 @@ class EventFormState with _$EventFormState {
     /// 메모
     String? memo,
 
-    // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-    // /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
-    // int? alarmMinutes,
+    /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
+    int? alarmMinutes,
 
     /// 폴더/보관함 이름
     String? folderName,
@@ -89,18 +88,17 @@ class EventFormState with _$EventFormState {
     return startMinutes <= endMinutes;
   }
 
-  /// TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // /// 알림 텍스트 변환
-  // String? get alarmText {
-  //   if (alarmMinutes == null) return null;
-  //   if (alarmMinutes == 0) {
-  //     return timeSetting ? '일정 시작' : '이벤트 당일(09:00)';
-  //   }
-  //   if (alarmMinutes == 10080) return '1주 전';
-  //   if (alarmMinutes! < 60) return '$alarmMinutes분 전';
-  //   if (alarmMinutes! < 1440) return '${alarmMinutes! ~/ 60}시간 전';
-  //   return '${alarmMinutes! ~/ 1440}일 전';
-  // }
+  /// 알림 텍스트 변환
+  String? get alarmText {
+    if (alarmMinutes == null) return null;
+    if (alarmMinutes == 0) {
+      return timeSetting ? '일정 시작' : '이벤트 당일(09:00)';
+    }
+    if (alarmMinutes == 10080) return '1주 전';
+    if (alarmMinutes! < 60) return '$alarmMinutes분 전';
+    if (alarmMinutes! < 1440) return '${alarmMinutes! ~/ 60}시간 전';
+    return '${alarmMinutes! ~/ 1440}일 전';
+  }
 
   bool _isSameDay(DateTime a, DateTime b) {
     return a.year == b.year && a.month == b.month && a.day == b.day;
@@ -155,8 +153,7 @@ class EventFormController extends Notifier<EventFormState> {
       endTime: endTime,
       timeSetting: detail.timeSetting,
       memo: detail.memo.isEmpty ? null : detail.memo,
-      // TODO(알림-비활성화): 테스트 중 임시 주석
-      // alarmMinutes: detail.alarmState ? detail.alarmOffsetMinutes : null,
+      alarmMinutes: detail.alarmState ? detail.alarmOffsetMinutes : null,
       folderName: detail.foldersTitle.isEmpty ? null : detail.foldersTitle,
       foldersId: detail.foldersId > 0 ? detail.foldersId : null,
       appColorToken: colorToken ?? EventColorToken.blue300,
@@ -232,11 +229,10 @@ class EventFormController extends Notifier<EventFormState> {
     state = state.copyWith(memo: value);
   }
 
-  /// TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // /// 알림 설정 업데이트
-  // void updateAlarm(int? minutes) {
-  //   state = state.copyWith(alarmMinutes: minutes);
-  // }
+  /// 알림 설정 업데이트
+  void updateAlarm(int? minutes) {
+    state = state.copyWith(alarmMinutes: minutes);
+  }
 
   /// 폴더 업데이트
   void updateFolder(String? value) {

--- a/lib/controllers/event_form_controller.freezed.dart
+++ b/lib/controllers/event_form_controller.freezed.dart
@@ -39,10 +39,11 @@ mixin _$EventFormState {
   bool get timeSetting => throw _privateConstructorUsedError;
 
   /// 메모
-  String? get memo =>
-      throw _privateConstructorUsedError; // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
-  // int? alarmMinutes,
+  String? get memo => throw _privateConstructorUsedError;
+
+  /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
+  int? get alarmMinutes => throw _privateConstructorUsedError;
+
   /// 폴더/보관함 이름
   String? get folderName => throw _privateConstructorUsedError;
 
@@ -81,6 +82,7 @@ abstract class $EventFormStateCopyWith<$Res> {
     String? endTime,
     bool timeSetting,
     String? memo,
+    int? alarmMinutes,
     String? folderName,
     int? foldersId,
     EventColorToken? appColorToken,
@@ -112,6 +114,7 @@ class _$EventFormStateCopyWithImpl<$Res, $Val extends EventFormState>
     Object? endTime = freezed,
     Object? timeSetting = null,
     Object? memo = freezed,
+    Object? alarmMinutes = freezed,
     Object? folderName = freezed,
     Object? foldersId = freezed,
     Object? appColorToken = freezed,
@@ -152,6 +155,10 @@ class _$EventFormStateCopyWithImpl<$Res, $Val extends EventFormState>
                 ? _value.memo
                 : memo // ignore: cast_nullable_to_non_nullable
                       as String?,
+            alarmMinutes: freezed == alarmMinutes
+                ? _value.alarmMinutes
+                : alarmMinutes // ignore: cast_nullable_to_non_nullable
+                      as int?,
             folderName: freezed == folderName
                 ? _value.folderName
                 : folderName // ignore: cast_nullable_to_non_nullable
@@ -196,6 +203,7 @@ abstract class _$$EventFormStateImplCopyWith<$Res>
     String? endTime,
     bool timeSetting,
     String? memo,
+    int? alarmMinutes,
     String? folderName,
     int? foldersId,
     EventColorToken? appColorToken,
@@ -226,6 +234,7 @@ class __$$EventFormStateImplCopyWithImpl<$Res>
     Object? endTime = freezed,
     Object? timeSetting = null,
     Object? memo = freezed,
+    Object? alarmMinutes = freezed,
     Object? folderName = freezed,
     Object? foldersId = freezed,
     Object? appColorToken = freezed,
@@ -266,6 +275,10 @@ class __$$EventFormStateImplCopyWithImpl<$Res>
             ? _value.memo
             : memo // ignore: cast_nullable_to_non_nullable
                   as String?,
+        alarmMinutes: freezed == alarmMinutes
+            ? _value.alarmMinutes
+            : alarmMinutes // ignore: cast_nullable_to_non_nullable
+                  as int?,
         folderName: freezed == folderName
             ? _value.folderName
             : folderName // ignore: cast_nullable_to_non_nullable
@@ -303,6 +316,7 @@ class _$EventFormStateImpl extends _EventFormState {
     this.endTime,
     this.timeSetting = false,
     this.memo,
+    this.alarmMinutes,
     this.folderName,
     this.foldersId,
     this.appColorToken,
@@ -343,9 +357,11 @@ class _$EventFormStateImpl extends _EventFormState {
   /// 메모
   @override
   final String? memo;
-  // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
-  // int? alarmMinutes,
+
+  /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
+  @override
+  final int? alarmMinutes;
+
   /// 폴더/보관함 이름
   @override
   final String? folderName;
@@ -369,7 +385,7 @@ class _$EventFormStateImpl extends _EventFormState {
 
   @override
   String toString() {
-    return 'EventFormState(id: $id, title: $title, startDate: $startDate, endDate: $endDate, startTime: $startTime, endTime: $endTime, timeSetting: $timeSetting, memo: $memo, folderName: $folderName, foldersId: $foldersId, appColorToken: $appColorToken, isSaving: $isSaving, errorMessage: $errorMessage)';
+    return 'EventFormState(id: $id, title: $title, startDate: $startDate, endDate: $endDate, startTime: $startTime, endTime: $endTime, timeSetting: $timeSetting, memo: $memo, alarmMinutes: $alarmMinutes, folderName: $folderName, foldersId: $foldersId, appColorToken: $appColorToken, isSaving: $isSaving, errorMessage: $errorMessage)';
   }
 
   @override
@@ -388,6 +404,8 @@ class _$EventFormStateImpl extends _EventFormState {
             (identical(other.timeSetting, timeSetting) ||
                 other.timeSetting == timeSetting) &&
             (identical(other.memo, memo) || other.memo == memo) &&
+            (identical(other.alarmMinutes, alarmMinutes) ||
+                other.alarmMinutes == alarmMinutes) &&
             (identical(other.folderName, folderName) ||
                 other.folderName == folderName) &&
             (identical(other.foldersId, foldersId) ||
@@ -411,6 +429,7 @@ class _$EventFormStateImpl extends _EventFormState {
     endTime,
     timeSetting,
     memo,
+    alarmMinutes,
     folderName,
     foldersId,
     appColorToken,
@@ -440,6 +459,7 @@ abstract class _EventFormState extends EventFormState {
     final String? endTime,
     final bool timeSetting,
     final String? memo,
+    final int? alarmMinutes,
     final String? folderName,
     final int? foldersId,
     final EventColorToken? appColorToken,
@@ -478,9 +498,12 @@ abstract class _EventFormState extends EventFormState {
 
   /// 메모
   @override
-  String? get memo; // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
-  // int? alarmMinutes,
+  String? get memo;
+
+  /// 알림 설정 (분 단위, 예: 10 = 10분 전, 0 = 일정 시작 시)
+  @override
+  int? get alarmMinutes;
+
   /// 폴더/보관함 이름
   @override
   String? get folderName;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import 'package:firebase_core/firebase_core.dart';
-// import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -12,20 +11,19 @@ import 'package:flutter/services.dart';
 
 import 'controllers/auth_controller.dart';
 import 'controllers/bootstrap_controller.dart';
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import 'controllers/notifications_page_controller.dart';
-// import 'controllers/notifications_unread_count_controller.dart';
-// import 'core/constants/api_constants.dart';
-// import 'core/deep_link/toit_deep_link.dart';
+import 'controllers/notifications_page_controller.dart';
+import 'controllers/notifications_unread_count_controller.dart';
+import 'core/constants/api_constants.dart';
+import 'core/deep_link/toit_deep_link.dart';
 import 'core/network/api_client.dart';
 import 'core/theme/app_theme.dart';
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import 'firebase_options.dart';
+import 'firebase_options.dart';
 import 'services/auth_service.dart';
-// import 'services/fcm_registration_service.dart';
+import 'services/fcm_registration_service.dart';
 import 'views/screens/apple_name_input_screen.dart';
 import 'views/screens/login_screen.dart';
-import 'views/screens/navigation_shell.dart' show NavigationShell;
+import 'views/screens/navigation_shell.dart'
+    show NavigationShell, pendingDeepLinkUrlProvider;
 import 'views/screens/splash_retry_screen.dart';
 import 'views/screens/splash_screen.dart';
 import 'views/widgets/common/app_alert_dialog.dart';
@@ -36,13 +34,13 @@ Future<void> main() async {
 
   // Android는 google-services 플러그인이 네이티브에서 [DEFAULT] 앱을 자동 초기화하므로
   // Flutter에서 또 초기화하면 duplicate-app 예외가 발생한다. 이미 초기화된 경우 무시한다.
-  //try {
-  //  await Firebase.initializeApp(
-  //    options: DefaultFirebaseOptions.currentPlatform,
-  //  );
-  //} on FirebaseException catch (e) {
-  //  if (e.code != 'duplicate-app') rethrow;
-  //}
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } on FirebaseException catch (e) {
+    if (e.code != 'duplicate-app') rethrow;
+  }
 
   runApp(const ProviderScope(child: MyApp()));
 }
@@ -63,9 +61,8 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
   /// 부트스트랩이 너무 빨라 화면이 깜빡이는 인상을 주지 않기 위함.
   static const _minSplashDuration = Duration(milliseconds: 1500);
 
-  // TODO(FCM-비활성화): 테스트 중 임시 주석
-  // StreamSubscription<String>? _fcmTokenRefreshSub;
-  // StreamSubscription<RemoteMessage>? _fcmOnMessageSub;
+  StreamSubscription<String>? _fcmTokenRefreshSub;
+  StreamSubscription<RemoteMessage>? _fcmOnMessageSub;
 
   /// 스플래시 최소 노출 시간이 지난 뒤에만 true.
   /// `authState`가 먼저 확정되더라도 이 값이 false인 동안에는 스플래시를 유지한다.
@@ -75,151 +72,146 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       _androidShareInitialRoute;
   bool _showSessionExpiredNotice = false;
   bool _isSessionExpiredDialogShowing = false;
-  // TODO(FCM-비활성화): 테스트 중 임시 주석
-  // int? _pendingReadNotificationId;
+  int? _pendingReadNotificationId;
 
   @override
   void initState() {
     super.initState();
-    // TODO(FCM-비활성화): 테스트 중 임시 주석
-    // WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
     // ProviderScope 첫 빌드가 안정화된 뒤 부트스트랩을 시작한다.
     // initState 즉시 provider state를 변경하면 프레임워크 assert와 충돌할 수 있다.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       unawaited(_initAuth());
     });
-    // TODO(FCM-비활성화): 테스트 중 임시 주석
-    // _bindFcmDeepLinks();
-    // _bindFcmTokenRefresh();
-    // _bindFcmForegroundIncoming();
+    _bindFcmDeepLinks();
+    _bindFcmTokenRefresh();
+    _bindFcmForegroundIncoming();
   }
 
   @override
   void dispose() {
-    // TODO(FCM-비활성화): 테스트 중 임시 주석
-    // WidgetsBinding.instance.removeObserver(this);
-    // _fcmTokenRefreshSub?.cancel();
-    // _fcmOnMessageSub?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
+    _fcmTokenRefreshSub?.cancel();
+    _fcmOnMessageSub?.cancel();
     super.dispose();
   }
 
-  // TODO(FCM-비활성화): 테스트 중 임시 주석
-  // @override
-  // void didChangeAppLifecycleState(AppLifecycleState state) {
-  //   super.didChangeAppLifecycleState(state);
-  //   if (state != AppLifecycleState.resumed) return;
-  //   final auth = ref.read(authProvider);
-  //   if (auth.status != AuthStatus.authenticated) return;
-  //   unawaited(
-  //     ref
-  //         .read(fcmRegistrationServiceProvider)
-  //         .syncServerRegistration(promptForPermission: false),
-  //   );
-  //   // 백그라운드/종료 상태에서 도착한 알림은 포그라운드 핸들러를 거치지 못하므로
-  //   // resume 시점에 카운트는 즉시 갱신하고, 리스트는 dirty만 찍어 다음 진입 시
-  //   // 자동 동기화되도록 한다.
-  //   _refreshUnreadCountIfAuthenticated();
-  //   _markNotificationsPageDirtyIfAuthenticated();
-  // }
-  //
-  // /// 로그인 중일 때만 FCM 토큰 갱신을 서버에 반영
-  // void _bindFcmTokenRefresh() {
-  //   _fcmTokenRefreshSub = FirebaseMessaging.instance.onTokenRefresh.listen((
-  //     String newToken,
-  //   ) {
-  //     final auth = ref.read(authProvider);
-  //     if (auth.status != AuthStatus.authenticated) return;
-  //     unawaited(
-  //       ref
-  //           .read(fcmRegistrationServiceProvider)
-  //           .syncServerRegistration(
-  //             promptForPermission: false,
-  //             fcmToken: newToken,
-  //           ),
-  //     );
-  //   });
-  // }
-  //
-  // void _bindFcmDeepLinks() {
-  //   FirebaseMessaging.onMessageOpenedApp.listen(_onFcmMessageOpened);
-  //   FirebaseMessaging.instance.getInitialMessage().then((
-  //     RemoteMessage? message,
-  //   ) {
-  //     if (message != null) _onFcmMessageOpened(message);
-  //   });
-  // }
-  //
-  // void _onFcmMessageOpened(RemoteMessage message) {
-  //   final didScheduleRead = _markNotificationAsReadFromFcm(message);
-  //   if (!didScheduleRead) {
-  //     _refreshUnreadCountIfAuthenticated();
-  //   }
-  //   final url = ToitDeepLink.extractUrlFromFcmData(message.data);
-  //   if (url == null) return;
-  //   ref.read(pendingDeepLinkUrlProvider.notifier).state = url;
-  // }
-  //
-  // bool _markNotificationAsReadFromFcm(RemoteMessage message) {
-  //   final notificationId = ToitDeepLink.extractNotificationIdFromFcmData(
-  //     message.data,
-  //   );
-  //   if (notificationId == null) return false;
-  //   final authState = ref.read(authProvider);
-  //   if (authState.status != AuthStatus.authenticated) {
-  //     // cold start에서 인증 복구보다 push open 콜백이 먼저 들어오면
-  //     // 읽음 PATCH를 놓치지 않도록 인증 완료 시점까지 보관한다.
-  //     _pendingReadNotificationId = notificationId;
-  //     return false;
-  //   }
-  //   unawaited(_patchNotificationRead(notificationId));
-  //   return true;
-  // }
-  //
-  // Future<void> _patchNotificationRead(int notificationId) async {
-  //   try {
-  //     await ref
-  //         .read(apiClientProvider)
-  //         .patch<void>(ApiConstants.notificationReadPath(notificationId));
-  //   } catch (_) {
-  //     return;
-  //   }
-  //   _refreshUnreadCountIfAuthenticated();
-  // }
-  //
-  // /// 포그라운드 알림 수신 시 배지(count)는 즉시 갱신하고,
-  // /// 리스트 캐시는 dirty 표시만 남겨 진입 시점에 동기화되도록 한다.
-  // void _bindFcmForegroundIncoming() {
-  //   _fcmOnMessageSub = FirebaseMessaging.onMessage.listen((_) {
-  //     _refreshUnreadCountIfAuthenticated();
-  //     _markNotificationsPageDirtyIfAuthenticated();
-  //   });
-  // }
-  //
-  // void _refreshUnreadCountIfAuthenticated() {
-  //   final cacheKey = _resolveAuthenticatedCacheKey();
-  //   if (cacheKey == null) return;
-  //   unawaited(
-  //     ref.read(notificationsUnreadCountProvider(cacheKey).notifier).refresh(),
-  //   );
-  // }
-  //
-  // void _markNotificationsPageDirtyIfAuthenticated() {
-  //   final cacheKey = _resolveAuthenticatedCacheKey();
-  //   if (cacheKey == null) return;
-  //   ref.read(notificationsPageDirtyProvider(cacheKey).notifier).state = true;
-  // }
-  //
-  // /// 인증된 사용자에 대한 (userId, refreshTick) 캐시 키를 반환.
-  // /// 미인증이면 null을 돌려 호출자가 조용히 빠져나오게 한다.
-  // (int, int)? _resolveAuthenticatedCacheKey() {
-  //   final authState = ref.read(authProvider);
-  //   final userId = authState.userId;
-  //   if (authState.status != AuthStatus.authenticated || userId == null) {
-  //     return null;
-  //   }
-  //   return (userId, ref.read(authSessionRefreshTickProvider));
-  // }
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state != AppLifecycleState.resumed) return;
+    final auth = ref.read(authProvider);
+    if (auth.status != AuthStatus.authenticated) return;
+    unawaited(
+      ref
+          .read(fcmRegistrationServiceProvider)
+          .syncServerRegistration(promptForPermission: false),
+    );
+    // 백그라운드/종료 상태에서 도착한 알림은 포그라운드 핸들러를 거치지 못하므로
+    // resume 시점에 카운트는 즉시 갱신하고, 리스트는 dirty만 찍어 다음 진입 시
+    // 자동 동기화되도록 한다.
+    _refreshUnreadCountIfAuthenticated();
+    _markNotificationsPageDirtyIfAuthenticated();
+  }
+
+  /// 로그인 중일 때만 FCM 토큰 갱신을 서버에 반영
+  void _bindFcmTokenRefresh() {
+    _fcmTokenRefreshSub = FirebaseMessaging.instance.onTokenRefresh.listen((
+      String newToken,
+    ) {
+      final auth = ref.read(authProvider);
+      if (auth.status != AuthStatus.authenticated) return;
+      unawaited(
+        ref
+            .read(fcmRegistrationServiceProvider)
+            .syncServerRegistration(
+              promptForPermission: false,
+              fcmToken: newToken,
+            ),
+      );
+    });
+  }
+
+  void _bindFcmDeepLinks() {
+    FirebaseMessaging.onMessageOpenedApp.listen(_onFcmMessageOpened);
+    FirebaseMessaging.instance.getInitialMessage().then((
+      RemoteMessage? message,
+    ) {
+      if (message != null) _onFcmMessageOpened(message);
+    });
+  }
+
+  void _onFcmMessageOpened(RemoteMessage message) {
+    final didScheduleRead = _markNotificationAsReadFromFcm(message);
+    if (!didScheduleRead) {
+      _refreshUnreadCountIfAuthenticated();
+    }
+    final url = ToitDeepLink.extractUrlFromFcmData(message.data);
+    if (url == null) return;
+    ref.read(pendingDeepLinkUrlProvider.notifier).state = url;
+  }
+
+  bool _markNotificationAsReadFromFcm(RemoteMessage message) {
+    final notificationId = ToitDeepLink.extractNotificationIdFromFcmData(
+      message.data,
+    );
+    if (notificationId == null) return false;
+    final authState = ref.read(authProvider);
+    if (authState.status != AuthStatus.authenticated) {
+      // cold start에서 인증 복구보다 push open 콜백이 먼저 들어오면
+      // 읽음 PATCH를 놓치지 않도록 인증 완료 시점까지 보관한다.
+      _pendingReadNotificationId = notificationId;
+      return false;
+    }
+    unawaited(_patchNotificationRead(notificationId));
+    return true;
+  }
+
+  Future<void> _patchNotificationRead(int notificationId) async {
+    try {
+      await ref
+          .read(apiClientProvider)
+          .patch<void>(ApiConstants.notificationReadPath(notificationId));
+    } catch (_) {
+      return;
+    }
+    _refreshUnreadCountIfAuthenticated();
+  }
+
+  /// 포그라운드 알림 수신 시 배지(count)는 즉시 갱신하고,
+  /// 리스트 캐시는 dirty 표시만 남겨 진입 시점에 동기화되도록 한다.
+  void _bindFcmForegroundIncoming() {
+    _fcmOnMessageSub = FirebaseMessaging.onMessage.listen((_) {
+      _refreshUnreadCountIfAuthenticated();
+      _markNotificationsPageDirtyIfAuthenticated();
+    });
+  }
+
+  void _refreshUnreadCountIfAuthenticated() {
+    final cacheKey = _resolveAuthenticatedCacheKey();
+    if (cacheKey == null) return;
+    unawaited(
+      ref.read(notificationsUnreadCountProvider(cacheKey).notifier).refresh(),
+    );
+  }
+
+  void _markNotificationsPageDirtyIfAuthenticated() {
+    final cacheKey = _resolveAuthenticatedCacheKey();
+    if (cacheKey == null) return;
+    ref.read(notificationsPageDirtyProvider(cacheKey).notifier).state = true;
+  }
+
+  /// 인증된 사용자에 대한 (userId, refreshTick) 캐시 키를 반환.
+  /// 미인증이면 null을 돌려 호출자가 조용히 빠져나오게 한다.
+  (int, int)? _resolveAuthenticatedCacheKey() {
+    final authState = ref.read(authProvider);
+    final userId = authState.userId;
+    if (authState.status != AuthStatus.authenticated || userId == null) {
+      return null;
+    }
+    return (userId, ref.read(authSessionRefreshTickProvider));
+  }
 
   Future<void> _initAuth() async {
     if (!mounted) return;
@@ -385,8 +377,7 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
   void _handleAuthStatusChanged(AuthStatus? previous, AuthStatus next) {
     if (next == AuthStatus.authenticated) {
       _showSessionExpiredNotice = false;
-      // TODO(FCM-비활성화): 테스트 중 임시 주석
-      // _consumePendingNotificationRead();
+      _consumePendingNotificationRead();
       return;
     }
     if (next != AuthStatus.unauthenticated || !_showSessionExpiredNotice) {
@@ -422,13 +413,12 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
     });
   }
 
-  // TODO(FCM-비활성화): 테스트 중 임시 주석
-  // void _consumePendingNotificationRead() {
-  //   final notificationId = _pendingReadNotificationId;
-  //   if (notificationId == null) return;
-  //   _pendingReadNotificationId = null;
-  //   unawaited(_patchNotificationRead(notificationId));
-  // }
+  void _consumePendingNotificationRead() {
+    final notificationId = _pendingReadNotificationId;
+    if (notificationId == null) return;
+    _pendingReadNotificationId = null;
+    unawaited(_patchNotificationRead(notificationId));
+  }
 }
 
 /// Android 외부 공유 진입에서 Flutter 부트스트랩이 끝나기 전 보여주는

--- a/lib/models/dto/search_response_dto.dart
+++ b/lib/models/dto/search_response_dto.dart
@@ -76,9 +76,8 @@ class SearchScheduleItemDto with _$SearchScheduleItemDto {
     @Default('') String endDate,
     String? startTime,
     String? endTime,
-    // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-    // @Default(false) bool alarmState,
-    // @Default(0) int alarmOffsetMinutes,
+    @Default(false) bool alarmState,
+    @Default(0) int alarmOffsetMinutes,
     @Default('') String memo,
   }) = _SearchScheduleItemDto;
 

--- a/lib/models/dto/search_response_dto.freezed.dart
+++ b/lib/models/dto/search_response_dto.freezed.dart
@@ -686,10 +686,9 @@ mixin _$SearchScheduleItemDto {
   String get startDate => throw _privateConstructorUsedError;
   String get endDate => throw _privateConstructorUsedError;
   String? get startTime => throw _privateConstructorUsedError;
-  String? get endTime =>
-      throw _privateConstructorUsedError; // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // @Default(false) bool alarmState,
-  // @Default(0) int alarmOffsetMinutes,
+  String? get endTime => throw _privateConstructorUsedError;
+  bool get alarmState => throw _privateConstructorUsedError;
+  int get alarmOffsetMinutes => throw _privateConstructorUsedError;
   String get memo => throw _privateConstructorUsedError;
 
   /// Serializes this SearchScheduleItemDto to a JSON map.
@@ -720,6 +719,8 @@ abstract class $SearchScheduleItemDtoCopyWith<$Res> {
     String endDate,
     String? startTime,
     String? endTime,
+    bool alarmState,
+    int alarmOffsetMinutes,
     String memo,
   });
 }
@@ -752,6 +753,8 @@ class _$SearchScheduleItemDtoCopyWithImpl<
     Object? endDate = null,
     Object? startTime = freezed,
     Object? endTime = freezed,
+    Object? alarmState = null,
+    Object? alarmOffsetMinutes = null,
     Object? memo = null,
   }) {
     return _then(
@@ -796,6 +799,14 @@ class _$SearchScheduleItemDtoCopyWithImpl<
                 ? _value.endTime
                 : endTime // ignore: cast_nullable_to_non_nullable
                       as String?,
+            alarmState: null == alarmState
+                ? _value.alarmState
+                : alarmState // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            alarmOffsetMinutes: null == alarmOffsetMinutes
+                ? _value.alarmOffsetMinutes
+                : alarmOffsetMinutes // ignore: cast_nullable_to_non_nullable
+                      as int,
             memo: null == memo
                 ? _value.memo
                 : memo // ignore: cast_nullable_to_non_nullable
@@ -826,6 +837,8 @@ abstract class _$$SearchScheduleItemDtoImplCopyWith<$Res>
     String endDate,
     String? startTime,
     String? endTime,
+    bool alarmState,
+    int alarmOffsetMinutes,
     String memo,
   });
 }
@@ -855,6 +868,8 @@ class __$$SearchScheduleItemDtoImplCopyWithImpl<$Res>
     Object? endDate = null,
     Object? startTime = freezed,
     Object? endTime = freezed,
+    Object? alarmState = null,
+    Object? alarmOffsetMinutes = null,
     Object? memo = null,
   }) {
     return _then(
@@ -899,6 +914,14 @@ class __$$SearchScheduleItemDtoImplCopyWithImpl<$Res>
             ? _value.endTime
             : endTime // ignore: cast_nullable_to_non_nullable
                   as String?,
+        alarmState: null == alarmState
+            ? _value.alarmState
+            : alarmState // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        alarmOffsetMinutes: null == alarmOffsetMinutes
+            ? _value.alarmOffsetMinutes
+            : alarmOffsetMinutes // ignore: cast_nullable_to_non_nullable
+                  as int,
         memo: null == memo
             ? _value.memo
             : memo // ignore: cast_nullable_to_non_nullable
@@ -922,6 +945,8 @@ class _$SearchScheduleItemDtoImpl implements _SearchScheduleItemDto {
     this.endDate = '',
     this.startTime,
     this.endTime,
+    this.alarmState = false,
+    this.alarmOffsetMinutes = 0,
     this.memo = '',
   });
 
@@ -956,16 +981,19 @@ class _$SearchScheduleItemDtoImpl implements _SearchScheduleItemDto {
   final String? startTime;
   @override
   final String? endTime;
-  // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // @Default(false) bool alarmState,
-  // @Default(0) int alarmOffsetMinutes,
+  @override
+  @JsonKey()
+  final bool alarmState;
+  @override
+  @JsonKey()
+  final int alarmOffsetMinutes;
   @override
   @JsonKey()
   final String memo;
 
   @override
   String toString() {
-    return 'SearchScheduleItemDto(usersId: $usersId, schedulesId: $schedulesId, title: $title, foldersId: $foldersId, foldersTitle: $foldersTitle, timeSetting: $timeSetting, startDate: $startDate, endDate: $endDate, startTime: $startTime, endTime: $endTime, memo: $memo)';
+    return 'SearchScheduleItemDto(usersId: $usersId, schedulesId: $schedulesId, title: $title, foldersId: $foldersId, foldersTitle: $foldersTitle, timeSetting: $timeSetting, startDate: $startDate, endDate: $endDate, startTime: $startTime, endTime: $endTime, alarmState: $alarmState, alarmOffsetMinutes: $alarmOffsetMinutes, memo: $memo)';
   }
 
   @override
@@ -989,6 +1017,10 @@ class _$SearchScheduleItemDtoImpl implements _SearchScheduleItemDto {
             (identical(other.startTime, startTime) ||
                 other.startTime == startTime) &&
             (identical(other.endTime, endTime) || other.endTime == endTime) &&
+            (identical(other.alarmState, alarmState) ||
+                other.alarmState == alarmState) &&
+            (identical(other.alarmOffsetMinutes, alarmOffsetMinutes) ||
+                other.alarmOffsetMinutes == alarmOffsetMinutes) &&
             (identical(other.memo, memo) || other.memo == memo));
   }
 
@@ -1006,6 +1038,8 @@ class _$SearchScheduleItemDtoImpl implements _SearchScheduleItemDto {
     endDate,
     startTime,
     endTime,
+    alarmState,
+    alarmOffsetMinutes,
     memo,
   );
 
@@ -1039,6 +1073,8 @@ abstract class _SearchScheduleItemDto implements SearchScheduleItemDto {
     final String endDate,
     final String? startTime,
     final String? endTime,
+    final bool alarmState,
+    final int alarmOffsetMinutes,
     final String memo,
   }) = _$SearchScheduleItemDtoImpl;
 
@@ -1066,9 +1102,11 @@ abstract class _SearchScheduleItemDto implements SearchScheduleItemDto {
   @override
   String? get startTime;
   @override
-  String? get endTime; // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // @Default(false) bool alarmState,
-  // @Default(0) int alarmOffsetMinutes,
+  String? get endTime;
+  @override
+  bool get alarmState;
+  @override
+  int get alarmOffsetMinutes;
   @override
   String get memo;
 

--- a/lib/models/dto/search_response_dto.g.dart
+++ b/lib/models/dto/search_response_dto.g.dart
@@ -95,6 +95,8 @@ _$SearchScheduleItemDtoImpl _$$SearchScheduleItemDtoImplFromJson(
   endDate: json['endDate'] as String? ?? '',
   startTime: json['startTime'] as String?,
   endTime: json['endTime'] as String?,
+  alarmState: json['alarmState'] as bool? ?? false,
+  alarmOffsetMinutes: (json['alarmOffsetMinutes'] as num?)?.toInt() ?? 0,
   memo: json['memo'] as String? ?? '',
 );
 
@@ -111,6 +113,8 @@ Map<String, dynamic> _$$SearchScheduleItemDtoImplToJson(
   'endDate': instance.endDate,
   'startTime': instance.startTime,
   'endTime': instance.endTime,
+  'alarmState': instance.alarmState,
+  'alarmOffsetMinutes': instance.alarmOffsetMinutes,
   'memo': instance.memo,
 };
 

--- a/lib/models/schedule/schedule_response.dart
+++ b/lib/models/schedule/schedule_response.dart
@@ -88,9 +88,8 @@ class ScheduleDetailResponse with _$ScheduleDetailResponse {
     String? startTime,
     String? endTime,
     String? appColor,
-    // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-    // @Default(false) bool alarmState,
-    // @Default(0) int alarmOffsetMinutes,
+    @Default(false) bool alarmState,
+    @Default(0) int alarmOffsetMinutes,
     @JsonKey(fromJson: _stringFromJson) @Default('') String memo,
   }) = _ScheduleDetailResponse;
 

--- a/lib/models/schedule/schedule_response.freezed.dart
+++ b/lib/models/schedule/schedule_response.freezed.dart
@@ -1054,10 +1054,9 @@ mixin _$ScheduleDetailResponse {
   String get endDate => throw _privateConstructorUsedError;
   String? get startTime => throw _privateConstructorUsedError;
   String? get endTime => throw _privateConstructorUsedError;
-  String? get appColor =>
-      throw _privateConstructorUsedError; // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // @Default(false) bool alarmState,
-  // @Default(0) int alarmOffsetMinutes,
+  String? get appColor => throw _privateConstructorUsedError;
+  bool get alarmState => throw _privateConstructorUsedError;
+  int get alarmOffsetMinutes => throw _privateConstructorUsedError;
   @JsonKey(fromJson: _stringFromJson)
   String get memo => throw _privateConstructorUsedError;
 
@@ -1090,6 +1089,8 @@ abstract class $ScheduleDetailResponseCopyWith<$Res> {
     String? startTime,
     String? endTime,
     String? appColor,
+    bool alarmState,
+    int alarmOffsetMinutes,
     @JsonKey(fromJson: _stringFromJson) String memo,
   });
 }
@@ -1123,6 +1124,8 @@ class _$ScheduleDetailResponseCopyWithImpl<
     Object? startTime = freezed,
     Object? endTime = freezed,
     Object? appColor = freezed,
+    Object? alarmState = null,
+    Object? alarmOffsetMinutes = null,
     Object? memo = null,
   }) {
     return _then(
@@ -1171,6 +1174,14 @@ class _$ScheduleDetailResponseCopyWithImpl<
                 ? _value.appColor
                 : appColor // ignore: cast_nullable_to_non_nullable
                       as String?,
+            alarmState: null == alarmState
+                ? _value.alarmState
+                : alarmState // ignore: cast_nullable_to_non_nullable
+                      as bool,
+            alarmOffsetMinutes: null == alarmOffsetMinutes
+                ? _value.alarmOffsetMinutes
+                : alarmOffsetMinutes // ignore: cast_nullable_to_non_nullable
+                      as int,
             memo: null == memo
                 ? _value.memo
                 : memo // ignore: cast_nullable_to_non_nullable
@@ -1202,6 +1213,8 @@ abstract class _$$ScheduleDetailResponseImplCopyWith<$Res>
     String? startTime,
     String? endTime,
     String? appColor,
+    bool alarmState,
+    int alarmOffsetMinutes,
     @JsonKey(fromJson: _stringFromJson) String memo,
   });
 }
@@ -1232,6 +1245,8 @@ class __$$ScheduleDetailResponseImplCopyWithImpl<$Res>
     Object? startTime = freezed,
     Object? endTime = freezed,
     Object? appColor = freezed,
+    Object? alarmState = null,
+    Object? alarmOffsetMinutes = null,
     Object? memo = null,
   }) {
     return _then(
@@ -1280,6 +1295,14 @@ class __$$ScheduleDetailResponseImplCopyWithImpl<$Res>
             ? _value.appColor
             : appColor // ignore: cast_nullable_to_non_nullable
                   as String?,
+        alarmState: null == alarmState
+            ? _value.alarmState
+            : alarmState // ignore: cast_nullable_to_non_nullable
+                  as bool,
+        alarmOffsetMinutes: null == alarmOffsetMinutes
+            ? _value.alarmOffsetMinutes
+            : alarmOffsetMinutes // ignore: cast_nullable_to_non_nullable
+                  as int,
         memo: null == memo
             ? _value.memo
             : memo // ignore: cast_nullable_to_non_nullable
@@ -1304,6 +1327,8 @@ class _$ScheduleDetailResponseImpl implements _ScheduleDetailResponse {
     this.startTime,
     this.endTime,
     this.appColor,
+    this.alarmState = false,
+    this.alarmOffsetMinutes = 0,
     @JsonKey(fromJson: _stringFromJson) this.memo = '',
   });
 
@@ -1340,16 +1365,19 @@ class _$ScheduleDetailResponseImpl implements _ScheduleDetailResponse {
   final String? endTime;
   @override
   final String? appColor;
-  // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // @Default(false) bool alarmState,
-  // @Default(0) int alarmOffsetMinutes,
+  @override
+  @JsonKey()
+  final bool alarmState;
+  @override
+  @JsonKey()
+  final int alarmOffsetMinutes;
   @override
   @JsonKey(fromJson: _stringFromJson)
   final String memo;
 
   @override
   String toString() {
-    return 'ScheduleDetailResponse(userId: $userId, schedulesId: $schedulesId, title: $title, foldersId: $foldersId, foldersTitle: $foldersTitle, timeSetting: $timeSetting, startDate: $startDate, endDate: $endDate, startTime: $startTime, endTime: $endTime, appColor: $appColor, memo: $memo)';
+    return 'ScheduleDetailResponse(userId: $userId, schedulesId: $schedulesId, title: $title, foldersId: $foldersId, foldersTitle: $foldersTitle, timeSetting: $timeSetting, startDate: $startDate, endDate: $endDate, startTime: $startTime, endTime: $endTime, appColor: $appColor, alarmState: $alarmState, alarmOffsetMinutes: $alarmOffsetMinutes, memo: $memo)';
   }
 
   @override
@@ -1375,6 +1403,10 @@ class _$ScheduleDetailResponseImpl implements _ScheduleDetailResponse {
             (identical(other.endTime, endTime) || other.endTime == endTime) &&
             (identical(other.appColor, appColor) ||
                 other.appColor == appColor) &&
+            (identical(other.alarmState, alarmState) ||
+                other.alarmState == alarmState) &&
+            (identical(other.alarmOffsetMinutes, alarmOffsetMinutes) ||
+                other.alarmOffsetMinutes == alarmOffsetMinutes) &&
             (identical(other.memo, memo) || other.memo == memo));
   }
 
@@ -1393,6 +1425,8 @@ class _$ScheduleDetailResponseImpl implements _ScheduleDetailResponse {
     startTime,
     endTime,
     appColor,
+    alarmState,
+    alarmOffsetMinutes,
     memo,
   );
 
@@ -1427,6 +1461,8 @@ abstract class _ScheduleDetailResponse implements ScheduleDetailResponse {
     final String? startTime,
     final String? endTime,
     final String? appColor,
+    final bool alarmState,
+    final int alarmOffsetMinutes,
     @JsonKey(fromJson: _stringFromJson) final String memo,
   }) = _$ScheduleDetailResponseImpl;
 
@@ -1460,9 +1496,11 @@ abstract class _ScheduleDetailResponse implements ScheduleDetailResponse {
   @override
   String? get endTime;
   @override
-  String? get appColor; // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-  // @Default(false) bool alarmState,
-  // @Default(0) int alarmOffsetMinutes,
+  String? get appColor;
+  @override
+  bool get alarmState;
+  @override
+  int get alarmOffsetMinutes;
   @override
   @JsonKey(fromJson: _stringFromJson)
   String get memo;

--- a/lib/models/schedule/schedule_response.g.dart
+++ b/lib/models/schedule/schedule_response.g.dart
@@ -106,6 +106,8 @@ _$ScheduleDetailResponseImpl _$$ScheduleDetailResponseImplFromJson(
   startTime: json['startTime'] as String?,
   endTime: json['endTime'] as String?,
   appColor: json['appColor'] as String?,
+  alarmState: json['alarmState'] as bool? ?? false,
+  alarmOffsetMinutes: (json['alarmOffsetMinutes'] as num?)?.toInt() ?? 0,
   memo: json['memo'] == null ? '' : _stringFromJson(json['memo']),
 );
 
@@ -123,5 +125,7 @@ Map<String, dynamic> _$$ScheduleDetailResponseImplToJson(
   'startTime': instance.startTime,
   'endTime': instance.endTime,
   'appColor': instance.appColor,
+  'alarmState': instance.alarmState,
+  'alarmOffsetMinutes': instance.alarmOffsetMinutes,
   'memo': instance.memo,
 };

--- a/lib/services/fcm_registration_service.dart
+++ b/lib/services/fcm_registration_service.dart
@@ -56,9 +56,6 @@ class FcmRegistrationService {
     bool promptForPermission = true,
     String? fcmToken,
   }) async {
-    // TODO(FCM-비활성화): 테스트 중 임시 주석
-    return;
-    /*
     try {
       final NotificationSettings settings;
       if (promptForPermission) {
@@ -74,7 +71,6 @@ class FcmRegistrationService {
     } catch (e, st) {
       // debugPrint('[FcmRegistration] 서버 FCM 등록 실패: $e\n$st');
     }
-    */
   }
 
   static bool _isPushAllowed(AuthorizationStatus status) {

--- a/lib/services/schedule_api_client.dart
+++ b/lib/services/schedule_api_client.dart
@@ -93,9 +93,8 @@ class ScheduleApiClient {
     String? startTime,
     String? endTime,
     String? memo,
-    // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-    // required bool alarmState,
-    // int alarmOffsetMinutes = 0,
+    required bool alarmState,
+    int alarmOffsetMinutes = 0,
     int? foldersId,
   }) async {
     final body = <String, dynamic>{
@@ -108,9 +107,8 @@ class ScheduleApiClient {
       'endDate': _formatDate(endDate),
       'endTime': timeSetting ? _formatTime(endTime) : null,
       'memo': memo ?? '',
-      // TODO(알림-비활성화): 테스트 중 임시 주석
-      // 'alarmState': alarmState,
-      // 'alarmOffsetMinutes': alarmOffsetMinutes,
+      'alarmState': alarmState,
+      'alarmOffsetMinutes': alarmOffsetMinutes,
     };
 
     // debugPrint('[일정 추가 API] Request: POST ${ApiConstants.baseUrl}/schedules');
@@ -155,9 +153,8 @@ class ScheduleApiClient {
     String? startTime,
     String? endTime,
     String? memo,
-    // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-    // required bool alarmState,
-    // int alarmOffsetMinutes = 0,
+    required bool alarmState,
+    int alarmOffsetMinutes = 0,
     int? foldersId,
   }) async {
     final body = <String, dynamic>{
@@ -171,9 +168,8 @@ class ScheduleApiClient {
       'startTime': timeSetting ? _formatTime(startTime) : null,
       'endTime': timeSetting ? _formatTime(endTime) : null,
       'memo': memo ?? '',
-      // TODO(알림-비활성화): 테스트 중 임시 주석
-      // 'alarmState': alarmState,
-      // 'alarmOffsetMinutes': alarmOffsetMinutes,
+      'alarmState': alarmState,
+      'alarmOffsetMinutes': alarmOffsetMinutes,
     };
 
     // print('[일정 수정 API] Request: PATCH ${ApiConstants.baseUrl}/schedules');

--- a/lib/views/screens/calendar_screen.dart
+++ b/lib/views/screens/calendar_screen.dart
@@ -4,8 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/constants/app_colors.dart';
 import 'search_screen.dart';
 import 'my_screen.dart';
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import 'notification_screen.dart';
+import 'notification_screen.dart';
 import '../widgets/calendar/calendar_widget.dart';
 import '../widgets/home/home_app_bar.dart';
 
@@ -25,14 +24,13 @@ class CalendarScreen extends ConsumerWidget {
     );
   }
 
-  // TODO(FCM-비활성화): 테스트 중 임시 주석
-  // void _openNotifications(BuildContext context) {
-  //   Navigator.of(context).push(
-  //     MaterialPageRoute<void>(
-  //       builder: (_) => const NotificationScreen(),
-  //     ),
-  //   );
-  // }
+  void _openNotifications(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const NotificationScreen(),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -44,8 +42,7 @@ class CalendarScreen extends ConsumerWidget {
           title: '캘린더',
           onMenuPressed: () => _openMy(context),
           onSearchPressed: () => _openSearch(context),
-          // TODO(FCM-비활성화): 테스트 중 임시 주석
-          // onNotificationPressed: () => _openNotifications(context),
+          onNotificationPressed: () => _openNotifications(context),
         ),
       ),
       body: const CalendarWidget(),

--- a/lib/views/screens/event_detail_screen.dart
+++ b/lib/views/screens/event_detail_screen.dart
@@ -5,10 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../controllers/calendar_controller.dart';
 import '../../controllers/event_form_controller.dart';
 import '../../core/constants/app_colors.dart';
-// TODO(알림-비활성화): 테스트 중 임시 주석
-// import '../../core/constants/alarm_constants.dart';
-// TODO(알림-비활성화): 테스트 중 임시 주석
-// import '../../core/widgets/app_toast.dart';
+import '../../core/constants/alarm_constants.dart';
+import '../../core/widgets/app_toast.dart';
 import '../widgets/common/app_snack_bar.dart';
 import '../../core/widgets/system_safe_area.dart';
 import '../../core/constants/event_assets.dart';
@@ -19,12 +17,10 @@ import '../../services/schedule_api_client.dart' show scheduleApiClientProvider;
 import '../widgets/common/app_divider.dart';
 import '../widgets/common/schedule_folder_search_sheet.dart';
 import '../widgets/common/bottom_bar_button.dart';
-// TODO(알림-비활성화): 테스트 중 임시 주석
-// import '../widgets/event/alarm_picker_sheet.dart';
+import '../widgets/event/alarm_picker_sheet.dart';
 import '../widgets/common/app_alert_dialog.dart';
 import '../widgets/common/confirm_dialog.dart';
-// TODO(알림-비활성화): 테스트 중 임시 주석
-// import '../widgets/event/event_alarm_section.dart';
+import '../widgets/event/event_alarm_section.dart';
 import '../widgets/event/event_folder_section.dart';
 import '../widgets/event/event_memo_section.dart';
 import '../widgets/event/event_section.dart';
@@ -32,14 +28,13 @@ import '../widgets/event/event_time_section.dart';
 import '../widgets/event/color_context_menu.dart';
 import 'folder_detail_screen.dart';
 
-/// TODO(알림-비활성화): 테스트 중 임시 주석
-// String _alarmOffsetToText({required int minutes, required bool timeSetting}) {
-//   if (minutes == 0) return timeSetting ? '일정 시작' : '이벤트 당일(09:00)';
-//   if (minutes == 10080) return '1주 전';
-//   if (minutes < 60) return '$minutes분 전';
-//   if (minutes < 1440) return '${minutes ~/ 60}시간 전';
-//   return '${minutes ~/ 1440}일 전';
-// }
+String _alarmOffsetToText({required int minutes, required bool timeSetting}) {
+  if (minutes == 0) return timeSetting ? '일정 시작' : '이벤트 당일(09:00)';
+  if (minutes == 10080) return '1주 전';
+  if (minutes < 60) return '$minutes분 전';
+  if (minutes < 1440) return '${minutes ~/ 60}시간 전';
+  return '${minutes ~/ 1440}일 전';
+}
 
 /// 일정 상세 화면
 class EventDetailScreen extends ConsumerStatefulWidget {
@@ -52,9 +47,8 @@ class EventDetailScreen extends ConsumerStatefulWidget {
 }
 
 class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
-  // TODO(알림-비활성화): 테스트 중 임시 주석
-  // static const _pastAlarmToastMessage =
-  //     '이미 지난 시점에는 알림을 설정할 수 없어요.';
+  static const _pastAlarmToastMessage =
+      '이미 지난 시점에는 알림을 설정할 수 없어요.';
 
   bool _isEditMode = false;
   late TextEditingController _titleController;
@@ -174,9 +168,8 @@ class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
         startTime: formState.startTime,
         endTime: formState.endTime,
         memo: formState.memo,
-        // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-        // alarmState: formState.alarmMinutes != null,
-        // alarmOffsetMinutes: formState.alarmMinutes ?? 0,
+        alarmState: formState.alarmMinutes != null,
+        alarmOffsetMinutes: formState.alarmMinutes ?? 0,
         foldersId: formState.foldersId,
       );
 
@@ -273,9 +266,8 @@ class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
         onTimeSettingChanged: _handleTimeSettingChanged,
         onFolderTap: _handleFolderTap,
         onClearFolderLink: _handleClearFolderLink,
-        // TODO(알림-비활성화): 테스트 중 임시 주석
-        // onAlarmTap: _handleAlarmTap,
-        // onAlarmToggleOff: _handleAlarmToggleOff,
+        onAlarmTap: _handleAlarmTap,
+        onAlarmToggleOff: _handleAlarmToggleOff,
         onMemoChanged: _handleMemoChanged,
       );
     }
@@ -348,13 +340,12 @@ class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
   }
 
   List<EventSectionItem> _buildSections(ScheduleDetailResponse detail) {
-    // TODO(알림-비활성화): 테스트 중 임시 주석
-    // final alarmText = detail.alarmState
-    //     ? _alarmOffsetToText(
-    //         minutes: detail.alarmOffsetMinutes,
-    //         timeSetting: detail.timeSetting,
-    //       )
-    //     : null;
+    final alarmText = detail.alarmState
+        ? _alarmOffsetToText(
+            minutes: detail.alarmOffsetMinutes,
+            timeSetting: detail.timeSetting,
+          )
+        : null;
 
     return [
       EventSectionItem(
@@ -377,17 +368,16 @@ class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
           isEditable: false,
         ),
       ),
-      // TODO(알림-비활성화): 테스트 중 임시 주석
-      // EventSectionItem(
-      //   iconSvgAsset: EventAssets.sectionNotification,
-      //   iconColor: SettingLayout1Tokens.sectionIconColor,
-      //   rowCrossAxisAlignment: CrossAxisAlignment.center,
-      //   child: EventAlarmSection(
-      //     alarmText: alarmText,
-      //     alarmEnabled: detail.alarmState,
-      //     isEditable: false,
-      //   ),
-      // ),
+      EventSectionItem(
+        iconSvgAsset: EventAssets.sectionNotification,
+        iconColor: SettingLayout1Tokens.sectionIconColor,
+        rowCrossAxisAlignment: CrossAxisAlignment.center,
+        child: EventAlarmSection(
+          alarmText: alarmText,
+          alarmEnabled: detail.alarmState,
+          isEditable: false,
+        ),
+      ),
       EventSectionItem(
         iconSvgAsset: EventAssets.sectionNote,
         iconColor: SettingLayout1Tokens.sectionIconColor,
@@ -506,18 +496,17 @@ class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
     }
   }
 
-  // TODO(알림-비활성화): 테스트 중 임시 주석
-  // void _handleAlarmTap() {
-  //   // 알림 추가 시 기본값으로 '일정 시작'(0분) 설정
-  //   if (ref.read(eventFormProvider).alarmMinutes == null) {
-  //     ref.read(eventFormProvider.notifier).updateAlarm(0);
-  //   }
-  //   _showAlarmPicker();
-  // }
-  //
-  // void _handleAlarmToggleOff() {
-  //   ref.read(eventFormProvider.notifier).updateAlarm(null);
-  // }
+  void _handleAlarmTap() {
+    // 알림 추가 시 기본값으로 '일정 시작'(0분) 설정
+    if (ref.read(eventFormProvider).alarmMinutes == null) {
+      ref.read(eventFormProvider.notifier).updateAlarm(0);
+    }
+    _showAlarmPicker();
+  }
+  
+  void _handleAlarmToggleOff() {
+    ref.read(eventFormProvider.notifier).updateAlarm(null);
+  }
 
   void _handleMemoChanged(String value) {
     ref
@@ -529,57 +518,56 @@ class _EventDetailScreenState extends ConsumerState<EventDetailScreen> {
     await showAppAlertDialog(context, message: '시작 날짜는 종료 날짜 이전이어야 합니다.');
   }
 
-  // TODO(알림-비활성화): 테스트 중 임시 주석
-  // void _showAlarmPicker() {
-  //   final formState = ref.read(eventFormProvider);
-  //   final isAllDayAlarmMode = !formState.timeSetting;
-  //   final options = isAllDayAlarmMode
-  //       ? AlarmUtils.allDayPresetOptions(
-  //           startDate: formState.startDate ?? DateTime.now(),
-  //         )
-  //       : AlarmUtils.predefinedOptions;
-  //
-  //   BottomSheetStyle.show<void>(
-  //     context,
-  //     showDragHandle: true,
-  //     child: Builder(
-  //       builder: (context) {
-  //         final currentMinutes = ref.watch(eventFormProvider).alarmMinutes;
-  //         return AlarmPickerSheet(
-  //           currentMinutes: currentMinutes,
-  //           options: options,
-  //           showCustomSetting: !isAllDayAlarmMode,
-  //           onOptionSelected: (minutes) {
-  //             ref.read(eventFormProvider.notifier).updateAlarm(minutes);
-  //           },
-  //           onDisabledOptionTap: (_) {
-  //             showAppToast(context, message: _pastAlarmToastMessage);
-  //           },
-  //           onCustomSettingTap: _showAlarmCustomPicker,
-  //         );
-  //       },
-  //     ),
-  //   );
-  // }
-  //
-  // void _showAlarmCustomPicker() {
-  //   final currentMinutes = ref.read(eventFormProvider).alarmMinutes;
-  //   final (initialValue, initialUnit) = AlarmUtils.fromMinutes(
-  //     currentMinutes ?? 60,
-  //   ); // 기본 1시간
-  //
-  //   BottomSheetStyle.show<void>(
-  //     context,
-  //     showDragHandle: true,
-  //     child: AlarmCustomPickerSheet(
-  //       initialValue: initialValue,
-  //       initialUnit: initialUnit,
-  //       onConfirm: (minutes) {
-  //         ref.read(eventFormProvider.notifier).updateAlarm(minutes);
-  //       },
-  //     ),
-  //   );
-  // }
+  void _showAlarmPicker() {
+    final formState = ref.read(eventFormProvider);
+    final isAllDayAlarmMode = !formState.timeSetting;
+    final options = isAllDayAlarmMode
+        ? AlarmUtils.allDayPresetOptions(
+            startDate: formState.startDate ?? DateTime.now(),
+          )
+        : AlarmUtils.predefinedOptions;
+  
+    BottomSheetStyle.show<void>(
+      context,
+      showDragHandle: true,
+      child: Builder(
+        builder: (context) {
+          final currentMinutes = ref.watch(eventFormProvider).alarmMinutes;
+          return AlarmPickerSheet(
+            currentMinutes: currentMinutes,
+            options: options,
+            showCustomSetting: !isAllDayAlarmMode,
+            onOptionSelected: (minutes) {
+              ref.read(eventFormProvider.notifier).updateAlarm(minutes);
+            },
+            onDisabledOptionTap: (_) {
+              showAppToast(context, message: _pastAlarmToastMessage);
+            },
+            onCustomSettingTap: _showAlarmCustomPicker,
+          );
+        },
+      ),
+    );
+  }
+  
+  void _showAlarmCustomPicker() {
+    final currentMinutes = ref.read(eventFormProvider).alarmMinutes;
+    final (initialValue, initialUnit) = AlarmUtils.fromMinutes(
+      currentMinutes ?? 60,
+    ); // 기본 1시간
+  
+    BottomSheetStyle.show<void>(
+      context,
+      showDragHandle: true,
+      child: AlarmCustomPickerSheet(
+        initialValue: initialValue,
+        initialUnit: initialUnit,
+        onConfirm: (minutes) {
+          ref.read(eventFormProvider.notifier).updateAlarm(minutes);
+        },
+      ),
+    );
+  }
 
   Future<void> _showDeleteConfirmDialog() async {
     final confirmed = await showConfirmDialog(
@@ -686,9 +674,8 @@ class _EventEditLayout extends StatelessWidget {
     required this.onTimeSettingChanged,
     required this.onFolderTap,
     required this.onClearFolderLink,
-    // TODO(알림-비활성화): 테스트 중 임시 주석
-    // required this.onAlarmTap,
-    // required this.onAlarmToggleOff,
+    required this.onAlarmTap,
+    required this.onAlarmToggleOff,
     required this.onMemoChanged,
   });
 
@@ -706,9 +693,8 @@ class _EventEditLayout extends StatelessWidget {
   final ValueChanged<bool> onTimeSettingChanged;
   final VoidCallback onFolderTap;
   final VoidCallback onClearFolderLink;
-  // TODO(알림-비활성화): 테스트 중 임시 주석
-  // final VoidCallback onAlarmTap;
-  // final VoidCallback onAlarmToggleOff;
+  final VoidCallback onAlarmTap;
+  final VoidCallback onAlarmToggleOff;
   final ValueChanged<String> onMemoChanged;
 
   @override
@@ -807,26 +793,25 @@ class _EventEditLayout extends StatelessWidget {
               ),
             ),
             const AppDivider(),
-            // TODO(알림-비활성화): 테스트 중 임시 주석 — 알림 섹션
-            // EventSection(
-            //   iconSvgAsset: EventAssets.sectionNotification,
-            //   iconColor: SettingLayout1Tokens.sectionIconColor,
-            //   rowCrossAxisAlignment: CrossAxisAlignment.center,
-            //   child: EventAlarmSection(
-            //     alarmText: formState.alarmText,
-            //     alarmEnabled: formState.alarmMinutes != null,
-            //     isEditable: true,
-            //     onAddTap: onAlarmTap,
-            //     onToggleChanged: (v) {
-            //       if (v) {
-            //         onAlarmTap();
-            //       } else {
-            //         onAlarmToggleOff();
-            //       }
-            //     },
-            //   ),
-            // ),
-            // const AppDivider(),
+            EventSection(
+              iconSvgAsset: EventAssets.sectionNotification,
+              iconColor: SettingLayout1Tokens.sectionIconColor,
+              rowCrossAxisAlignment: CrossAxisAlignment.center,
+              child: EventAlarmSection(
+                alarmText: formState.alarmText,
+                alarmEnabled: formState.alarmMinutes != null,
+                isEditable: true,
+                onAddTap: onAlarmTap,
+                onToggleChanged: (v) {
+                  if (v) {
+                    onAlarmTap();
+                  } else {
+                    onAlarmToggleOff();
+                  }
+                },
+              ),
+            ),
+            const AppDivider(),
             // 메모 섹션 (터치 시 포커스되어 바로 입력 가능)
             EventSection(
               iconSvgAsset: EventAssets.sectionNote,

--- a/lib/views/screens/event_form_screen.dart
+++ b/lib/views/screens/event_form_screen.dart
@@ -3,14 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../controllers/calendar_controller.dart';
 import '../../controllers/event_form_controller.dart';
-// TODO(알림-비활성화): 테스트 중 임시 주석
-// import '../../core/constants/alarm_constants.dart';
+import '../../core/constants/alarm_constants.dart';
 import '../../core/constants/app_colors.dart';
 import '../../core/constants/event_assets.dart';
 import '../../core/constants/event_color_tokens.dart';
 import '../../core/constants/setting_layout_tokens.dart';
-// TODO(알림-비활성화): 테스트 중 임시 주석
-// import '../../core/widgets/app_toast.dart';
+import '../../core/widgets/app_toast.dart';
 import '../../core/widgets/system_safe_area.dart';
 import '../../models/calendar/calendar_event.dart';
 import '../../services/schedule_api_client.dart' show scheduleApiClientProvider;
@@ -18,10 +16,9 @@ import '../widgets/common/app_alert_dialog.dart';
 import '../widgets/common/app_divider.dart';
 import '../widgets/common/confirm_dialog.dart';
 import '../widgets/common/schedule_folder_search_sheet.dart';
-// TODO(알림-비활성화): 테스트 중 임시 주석
-// import '../widgets/event/alarm_picker_sheet.dart';
+import '../widgets/event/alarm_picker_sheet.dart';
 import '../widgets/event/color_context_menu.dart';
-// import '../widgets/event/event_alarm_section.dart';
+import '../widgets/event/event_alarm_section.dart';
 import '../widgets/event/event_folder_section.dart';
 import '../widgets/event/event_memo_section.dart';
 import '../widgets/event/event_section.dart';
@@ -42,9 +39,8 @@ class EventFormScreen extends ConsumerStatefulWidget {
 }
 
 class _EventFormScreenState extends ConsumerState<EventFormScreen> {
-  // TODO(알림-비활성화): 테스트 중 임시 주석
-  // static const _pastAlarmToastMessage =
-  //     '이미 지난 시점에는 알림을 설정할 수 없어요.';
+  static const _pastAlarmToastMessage =
+      '이미 지난 시점에는 알림을 설정할 수 없어요.';
 
   late final TextEditingController _titleController;
   late final TextEditingController _memoController;
@@ -143,9 +139,8 @@ class _EventFormScreenState extends ConsumerState<EventFormScreen> {
         },
         onFolderTap: _handleFolderTap,
         onClearFolderLink: _handleClearFolderLink,
-        // TODO(알림-비활성화): 테스트 중 임시 주석
-        // onAlarmTap: _handleAlarmTap,
-        // onAlarmToggleOff: _handleAlarmToggleOff,
+        onAlarmTap: _handleAlarmTap,
+        onAlarmToggleOff: _handleAlarmToggleOff,
         onMemoChanged: _handleMemoChanged,
       ),
     );
@@ -221,9 +216,8 @@ class _EventFormScreenState extends ConsumerState<EventFormScreen> {
           startTime: formState.startTime,
           endTime: formState.endTime,
           memo: formState.memo,
-          // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-          // alarmState: formState.alarmMinutes != null,
-          // alarmOffsetMinutes: formState.alarmMinutes ?? 0,
+          alarmState: formState.alarmMinutes != null,
+          alarmOffsetMinutes: formState.alarmMinutes ?? 0,
           foldersId: formState.foldersId,
         );
 
@@ -258,9 +252,8 @@ class _EventFormScreenState extends ConsumerState<EventFormScreen> {
           startTime: formState.startTime,
           endTime: formState.endTime,
           memo: formState.memo,
-          // TODO(알림-비활성화): 테스트 중 임시 주석 — 백엔드 미지원
-          // alarmState: formState.alarmMinutes != null,
-          // alarmOffsetMinutes: formState.alarmMinutes ?? 0,
+          alarmState: formState.alarmMinutes != null,
+          alarmOffsetMinutes: formState.alarmMinutes ?? 0,
           foldersId: formState.foldersId,
         );
 
@@ -310,69 +303,68 @@ class _EventFormScreenState extends ConsumerState<EventFormScreen> {
     }
   }
 
-  // TODO(알림-비활성화): 테스트 중 임시 주석
-  // void _handleAlarmTap() {
-  //   // 알림 추가 시 기본값으로 '일정 시작'(0분) 설정
-  //   if (ref.read(eventFormProvider).alarmMinutes == null) {
-  //     ref.read(eventFormProvider.notifier).updateAlarm(0);
-  //   }
-  //   _showAlarmPicker();
-  // }
-  //
-  // void _handleAlarmToggleOff() {
-  //   ref.read(eventFormProvider.notifier).updateAlarm(null);
-  // }
-  //
-  // void _showAlarmPicker() {
-  //   final formState = ref.read(eventFormProvider);
-  //   final isAllDayAlarmMode = !formState.timeSetting;
-  //   final options = isAllDayAlarmMode
-  //       ? AlarmUtils.allDayPresetOptions(
-  //           startDate: formState.startDate ?? DateTime.now(),
-  //         )
-  //       : AlarmUtils.predefinedOptions;
-  //
-  //   BottomSheetStyle.show<void>(
-  //     context,
-  //     showDragHandle: true,
-  //     child: Builder(
-  //       builder: (context) {
-  //         final currentMinutes = ref.watch(eventFormProvider).alarmMinutes;
-  //         return AlarmPickerSheet(
-  //           currentMinutes: currentMinutes,
-  //           options: options,
-  //           showCustomSetting: !isAllDayAlarmMode,
-  //           onOptionSelected: (minutes) {
-  //             ref.read(eventFormProvider.notifier).updateAlarm(minutes);
-  //           },
-  //           onDisabledOptionTap: (_) {
-  //             showAppToast(context, message: _pastAlarmToastMessage);
-  //           },
-  //           onCustomSettingTap: _showAlarmCustomPicker,
-  //         );
-  //       },
-  //     ),
-  //   );
-  // }
-  //
-  // void _showAlarmCustomPicker() {
-  //   final currentMinutes = ref.read(eventFormProvider).alarmMinutes;
-  //   final (initialValue, initialUnit) = AlarmUtils.fromMinutes(
-  //     currentMinutes ?? 60,
-  //   ); // 기본 1시간
-  //
-  //   BottomSheetStyle.show<void>(
-  //     context,
-  //     showDragHandle: true,
-  //     child: AlarmCustomPickerSheet(
-  //       initialValue: initialValue,
-  //       initialUnit: initialUnit,
-  //       onConfirm: (minutes) {
-  //         ref.read(eventFormProvider.notifier).updateAlarm(minutes);
-  //       },
-  //     ),
-  //   );
-  // }
+  void _handleAlarmTap() {
+    // 알림 추가 시 기본값으로 '일정 시작'(0분) 설정
+    if (ref.read(eventFormProvider).alarmMinutes == null) {
+      ref.read(eventFormProvider.notifier).updateAlarm(0);
+    }
+    _showAlarmPicker();
+  }
+  
+  void _handleAlarmToggleOff() {
+    ref.read(eventFormProvider.notifier).updateAlarm(null);
+  }
+  
+  void _showAlarmPicker() {
+    final formState = ref.read(eventFormProvider);
+    final isAllDayAlarmMode = !formState.timeSetting;
+    final options = isAllDayAlarmMode
+        ? AlarmUtils.allDayPresetOptions(
+            startDate: formState.startDate ?? DateTime.now(),
+          )
+        : AlarmUtils.predefinedOptions;
+  
+    BottomSheetStyle.show<void>(
+      context,
+      showDragHandle: true,
+      child: Builder(
+        builder: (context) {
+          final currentMinutes = ref.watch(eventFormProvider).alarmMinutes;
+          return AlarmPickerSheet(
+            currentMinutes: currentMinutes,
+            options: options,
+            showCustomSetting: !isAllDayAlarmMode,
+            onOptionSelected: (minutes) {
+              ref.read(eventFormProvider.notifier).updateAlarm(minutes);
+            },
+            onDisabledOptionTap: (_) {
+              showAppToast(context, message: _pastAlarmToastMessage);
+            },
+            onCustomSettingTap: _showAlarmCustomPicker,
+          );
+        },
+      ),
+    );
+  }
+  
+  void _showAlarmCustomPicker() {
+    final currentMinutes = ref.read(eventFormProvider).alarmMinutes;
+    final (initialValue, initialUnit) = AlarmUtils.fromMinutes(
+      currentMinutes ?? 60,
+    ); // 기본 1시간
+  
+    BottomSheetStyle.show<void>(
+      context,
+      showDragHandle: true,
+      child: AlarmCustomPickerSheet(
+        initialValue: initialValue,
+        initialUnit: initialUnit,
+        onConfirm: (minutes) {
+          ref.read(eventFormProvider.notifier).updateAlarm(minutes);
+        },
+      ),
+    );
+  }
 
   Future<void> _showInvalidDateRangeDialog() async {
     await showAppAlertDialog(context, message: '시작 날짜는 종료 날짜 이전이어야 합니다.');
@@ -396,9 +388,8 @@ class _EventFormLayout extends StatelessWidget {
     required this.onEndTimeChanged,
     required this.onFolderTap,
     required this.onClearFolderLink,
-    // TODO(알림-비활성화): 테스트 중 임시 주석
-    // required this.onAlarmTap,
-    // required this.onAlarmToggleOff,
+    required this.onAlarmTap,
+    required this.onAlarmToggleOff,
     required this.onMemoChanged,
   });
 
@@ -416,9 +407,8 @@ class _EventFormLayout extends StatelessWidget {
   final ValueChanged<String> onEndTimeChanged;
   final VoidCallback onFolderTap;
   final VoidCallback onClearFolderLink;
-  // TODO(알림-비활성화): 테스트 중 임시 주석
-  // final VoidCallback onAlarmTap;
-  // final VoidCallback onAlarmToggleOff;
+  final VoidCallback onAlarmTap;
+  final VoidCallback onAlarmToggleOff;
   final ValueChanged<String> onMemoChanged;
 
   @override
@@ -519,26 +509,25 @@ class _EventFormLayout extends StatelessWidget {
                     ),
                   ),
                   const AppDivider(),
-                  // TODO(알림-비활성화): 테스트 중 임시 주석 — 알림 섹션
-                  // EventSection(
-                  //   iconSvgAsset: EventAssets.sectionNotification,
-                  //   iconColor: SettingLayout1Tokens.sectionIconColor,
-                  //   rowCrossAxisAlignment: CrossAxisAlignment.center,
-                  //   child: EventAlarmSection(
-                  //     alarmText: formState.alarmText,
-                  //     alarmEnabled: formState.alarmMinutes != null,
-                  //     isEditable: true,
-                  //     onAddTap: onAlarmTap,
-                  //     onToggleChanged: (v) {
-                  //       if (v) {
-                  //         onAlarmTap();
-                  //       } else {
-                  //         onAlarmToggleOff();
-                  //       }
-                  //     },
-                  //   ),
-                  // ),
-                  // const AppDivider(),
+                  EventSection(
+                    iconSvgAsset: EventAssets.sectionNotification,
+                    iconColor: SettingLayout1Tokens.sectionIconColor,
+                    rowCrossAxisAlignment: CrossAxisAlignment.center,
+                    child: EventAlarmSection(
+                      alarmText: formState.alarmText,
+                      alarmEnabled: formState.alarmMinutes != null,
+                      isEditable: true,
+                      onAddTap: onAlarmTap,
+                      onToggleChanged: (v) {
+                        if (v) {
+                          onAlarmTap();
+                        } else {
+                          onAlarmToggleOff();
+                        }
+                      },
+                    ),
+                  ),
+                  const AppDivider(),
                   // 메모 섹션
                   EventSection(
                     iconSvgAsset: EventAssets.sectionNote,

--- a/lib/views/screens/home_screen.dart
+++ b/lib/views/screens/home_screen.dart
@@ -6,8 +6,7 @@ import '../../core/constants/app_spacing.dart';
 import '../../core/widgets/system_safe_area.dart';
 import '../../core/constants/app_gradients.dart';
 import 'my_screen.dart';
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import 'notification_screen.dart';
+import 'notification_screen.dart';
 import 'search_screen.dart';
 import '../widgets/home/home_app_bar.dart';
 import '../widgets/home/greeting_section.dart';
@@ -39,14 +38,13 @@ class HomeScreen extends ConsumerWidget {
                 MaterialPageRoute<void>(builder: (_) => const SearchScreen()),
               );
             },
-            // TODO(FCM-비활성화): 테스트 중 임시 주석
-            // onNotificationPressed: () {
-            //   Navigator.of(context).push(
-            //     MaterialPageRoute<void>(
-            //       builder: (_) => const NotificationScreen(),
-            //     ),
-            //   );
-            // },
+            onNotificationPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => const NotificationScreen(),
+                ),
+              );
+            },
           ),
         ),
         body: homeState.isLoading

--- a/lib/views/screens/my_screen.dart
+++ b/lib/views/screens/my_screen.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../controllers/auth_controller.dart';
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import '../../controllers/notifications_unread_count_controller.dart';
+import '../../controllers/notifications_unread_count_controller.dart';
 import '../../core/constants/api_constants.dart';
 import '../../core/constants/app_assets.dart';
 import '../../providers/app_version_provider.dart';
@@ -101,15 +100,14 @@ class MyScreen extends ConsumerWidget {
                         builder: (_) => const SupportScreen(),
                       ),
                     );
-                    // TODO(FCM-비활성화): 테스트 중 임시 주석
-                    // await ref
-                    //     .read(
-                    //       notificationsUnreadCountProvider((
-                    //         userId,
-                    //         refreshTick,
-                    //       )).notifier,
-                    //     )
-                    //     .refresh();
+                    await ref
+                        .read(
+                          notificationsUnreadCountProvider((
+                            userId,
+                            refreshTick,
+                          )).notifier,
+                        )
+                        .refresh();
                     if (!context.mounted) return;
                     if (result != null && result.isNotEmpty) {
                       showAppSnackBar(context, result);

--- a/lib/views/widgets/home/home_app_bar.dart
+++ b/lib/views/widgets/home/home_app_bar.dart
@@ -2,9 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-// TODO(FCM-비활성화): 테스트 중 임시 주석
-// import '../../../controllers/auth_controller.dart';
-// import '../../../controllers/notifications_unread_count_controller.dart';
+import '../../../controllers/auth_controller.dart';
+import '../../../controllers/notifications_unread_count_controller.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_spacing.dart';
 import '../../../core/constants/app_assets.dart';
@@ -17,8 +16,7 @@ class HomeAppBar extends ConsumerWidget {
     this.titleWidget,
     this.onMenuPressed,
     this.onSearchPressed,
-    // TODO(FCM-비활성화): 테스트 중 임시 주석
-    // this.onNotificationPressed,
+    this.onNotificationPressed,
     this.useLightStatusBar = false,
   });
 
@@ -32,20 +30,18 @@ class HomeAppBar extends ConsumerWidget {
   final bool useLightStatusBar;
   final VoidCallback? onMenuPressed;
   final VoidCallback? onSearchPressed;
-  // TODO(FCM-비활성화): 테스트 중 임시 주석
-  // final VoidCallback? onNotificationPressed;
+  final VoidCallback? onNotificationPressed;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // TODO(FCM-비활성화): 테스트 중 임시 주석
-    // final userId = ref.watch(authProvider.select((state) => state.userId));
-    // final refreshTick = ref.watch(authSessionRefreshTickProvider);
-    // final unreadCountAsync = userId == null
-    //     ? const AsyncValue<int>.data(0)
-    //     : ref.watch(notificationsUnreadCountProvider((userId, refreshTick)));
-    // final unreadCount = unreadCountAsync.valueOrNull ?? 0;
-    // final hasUnread = unreadCount > 0;
-    // final badgeText = unreadCount > 99 ? '99+' : '$unreadCount';
+    final userId = ref.watch(authProvider.select((state) => state.userId));
+    final refreshTick = ref.watch(authSessionRefreshTickProvider);
+    final unreadCountAsync = userId == null
+        ? const AsyncValue<int>.data(0)
+        : ref.watch(notificationsUnreadCountProvider((userId, refreshTick)));
+    final unreadCount = unreadCountAsync.valueOrNull ?? 0;
+    final hasUnread = unreadCount > 0;
+    final badgeText = unreadCount > 99 ? '99+' : '$unreadCount';
     final systemOverlay = useLightStatusBar
         ? SystemUiOverlayStyle.light.copyWith(
             statusBarColor: Colors.transparent,
@@ -84,49 +80,48 @@ class HomeAppBar extends ConsumerWidget {
             icon: Image.asset(AppAssets.searchIcon, width: 24, height: 24),
             onPressed: onSearchPressed,
           ),
-          // TODO(FCM-비활성화): 테스트 중 임시 주석 — 알림 아이콘·배지
-          // Stack(
-          //   clipBehavior: Clip.none,
-          //   children: [
-          //     IconButton(
-          //       icon: Image.asset(
-          //         AppAssets.notificationIcon,
-          //         width: 24,
-          //         height: 24,
-          //       ),
-          //       onPressed: onNotificationPressed,
-          //     ),
-          //     if (hasUnread)
-          //       Positioned(
-          //         right: 4,
-          //         top: 6,
-          //         child: Container(
-          //           constraints: const BoxConstraints(
-          //             minWidth: 16,
-          //             minHeight: 16,
-          //           ),
-          //           padding: const EdgeInsets.symmetric(
-          //             horizontal: 4,
-          //             vertical: 1,
-          //           ),
-          //           decoration: BoxDecoration(
-          //             color: AppColors.badge,
-          //             borderRadius: BorderRadius.circular(10),
-          //           ),
-          //           alignment: Alignment.center,
-          //           child: Text(
-          //             badgeText,
-          //             style: const TextStyle(
-          //               color: Colors.white,
-          //               fontSize: 10,
-          //               fontWeight: FontWeight.w700,
-          //               height: 1.1,
-          //             ),
-          //           ),
-          //         ),
-          //       ),
-          //   ],
-          // ),
+          Stack(
+            clipBehavior: Clip.none,
+            children: [
+              IconButton(
+                icon: Image.asset(
+                  AppAssets.notificationIcon,
+                  width: 24,
+                  height: 24,
+                ),
+                onPressed: onNotificationPressed,
+              ),
+              if (hasUnread)
+                Positioned(
+                  right: 4,
+                  top: 6,
+                  child: Container(
+                    constraints: const BoxConstraints(
+                      minWidth: 16,
+                      minHeight: 16,
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColors.badge,
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                    alignment: Alignment.center,
+                    child: Text(
+                      badgeText,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                        height: 1.1,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## 배경

테스트를 위해 통째로 주석 처리해 두었던 **푸시 수신**과 **일정별 알림 설정**을
다시 켠다. 백엔드도 함께 열려서(`toIT_backend` PR #253) **설정부터 발송까지 전
구간이 동작하는 것을 실기기로 확인**했다.

주석 마커가 두 종류로 나뉘어 있었다.

```
TODO(FCM-비활성화)     푸시 수신·토큰·알림함
TODO(알림-비활성화)     일정 하나하나의 알림 설정 UI 와 요청 필드
```

---

## A. 푸시 수신 재활성화 — `b7cef40`

### `lib/main.dart`

`Firebase.initializeApp` 과 함께 아래 세 가지를 되살렸다.

| 함수 | 하는 일 |
|---|---|
| `_bindFcmDeepLinks` | `onMessageOpenedApp` 과 `getInitialMessage` 를 듣고, 알림을 눌러 들어온 경로를 `pendingDeepLinkUrlProvider` 에 넣는다. 앱이 꺼져 있다 알림으로 켜진 경우까지 다룬다 |
| `_bindFcmTokenRefresh` | `onTokenRefresh` 를 듣고 토큰이 바뀌면 서버에 다시 등록한다. 이게 없으면 어느 날 조용히 알림이 안 오기 시작한다 |
| `_bindFcmForegroundIncoming` | 앱이 떠 있는 동안 도착한 알림으로 안읽음 개수를 갱신하고 알림 목록을 `dirty` 로 표시한다 |

생명주기 옵저버도 함께 복구했다.

### `lib/controllers/auth_controller.dart`

로그인 성공 후 `syncServerRegistration(promptForPermission: true)` 을 호출해
토큰을 서버에 등록하고, 로그아웃 시 해제한다. 두 곳(최초 로그인 / 세션 복구)에서
호출한다.

### `lib/services/fcm_registration_service.dart`

서버 등록 경로의 주석을 걷었다.

### 화면 네 곳

| 파일 | 되살린 것 |
|---|---|
| `home_screen.dart` | 알림 화면 진입점 |
| `calendar_screen.dart` | 알림 화면 진입점 |
| `my_screen.dart` | `notificationsUnreadCountProvider` 로 안읽음 개수 표시 |
| `home_app_bar.dart` | 알림 아이콘 + 안읽음 배지 |

### 주석 안에 숨어 있던 깨진 코드

주석을 걷자 **컴파일되지 않는 코드**가 드러났다. 비활성화 이전부터 깨져 있던
것으로 보인다.

```
미정의 변수 $userId                          →  ${me.userId}
show NavigationShell 에 빠진 provider         →  pendingDeepLinkUrlProvider 추가
debugPrint 용 import 누락                     →  flutter/foundation.dart 추가
```

---

## B. 일정 알림 설정 재활성화 — `7ffc082`

`TODO(알림-비활성화)` 마커 35개를 걷었다.

### `lib/services/schedule_api_client.dart`

생성·수정 요청 본문에 알림 필드를 싣는다.

```dart
'alarmState': alarmState,
'alarmOffsetMinutes': alarmOffsetMinutes,
```

**이게 빠져 있어서 서버가 알림 값을 아예 못 받고 있었다.** 백엔드 로그로 확인한
결과 `alarmState=null` 로 찍혔다.

### `lib/controllers/event_form_controller.dart`

```dart
int? alarmMinutes,   // 몇 분 전에 알릴지. null 이면 알림을 안 고른 것
```

`alarmText` (알림 문구 변환), `updateAlarm` (설정 변경)을 함께 복구했다.

### `lib/views/screens/event_form_screen.dart` · `event_detail_screen.dart`

알림 섹션 UI 와 선택 시트를 되살리고, 저장 시 아래처럼 값을 만들어 보낸다.

```dart
alarmState: formState.alarmMinutes != null,
alarmOffsetMinutes: formState.alarmMinutes ?? 0,
```

**`alarmState` 는 앱에 따로 존재하는 스위치가 아니라 계산되는 값이다.** 알림
시간을 하나라도 골랐으면 `true`, 안 골랐으면 `false`.

```
alarmMinutes = null   알림 안 고름     →  alarmState = false
alarmMinutes = 0      일정 시작에 알림  →  alarmState = true,  offset 0
alarmMinutes = 10     10분 전에 알림    →  alarmState = true,  offset 10
```

「시간 설정」 토글과 「알림」 토글은 **다른 스위치**다. 시간 설정만 켜고 알림을
안 고르면 서버는 예약을 만들지 않는다.

### 모델 두 개

`schedule_response.dart`, `search_response_dto.dart` 의 알림 응답 필드를 복구했다.
`.freezed.dart` · `.g.dart` 는 `build_runner` 로 재생성했으며 직접 수정하지 않았다.

---

## 서버 쪽 변화 (참고)

응답도 실제 값이 온다. 기존에는 백엔드가 `alarmState` 자리에 `false`,
`alarmOffsetMinutes` 에 `null` 을 **하드코딩**해서 내려주고 있었다. 특히 일정
수정 응답은 **알림을 켜도 항상 꺼짐으로 답하던 상태**였다.

알림 시각을 정하는 규칙은 서버에 있다.

```
시간 설정 ON    시작 시각 − alarmOffsetMinutes
시간 설정 OFF   시작 날짜 오전 9시 (종일 일정)
```

---

## 받는 쪽에서 해야 할 것

### 1. `GoogleService-Info.plist` 를 직접 받아야 한다

`.gitignore` 에 있어 **브랜치를 받아도 따라오지 않는다.**

```
Firebase → toIT-test-server → ⚙️ 프로젝트 설정 → 내 앱
        → Apple 앱 「투잇 애플 (com.toit.ios)」 → GoogleService-Info.plist
```

받은 파일에서 아래를 확인한다.

```
PROJECT_ID       toit-test-server
GCM_SENDER_ID    348243451769
```

`998768329067` 이면 **운영 프로젝트 파일**이고, 그대로 쓰면 발송 시
`SENDER_ID_MISMATCH` 가 난다. 안드로이드(`google-services.json`)는 이미 맞는
프로젝트를 보고 있어 할 일이 없다.

### 2. iOS 의존성 다시 받기

`ios/Podfile.lock` 이 갱신됐다.

```bash
cd ios && pod install
```

---

## 검토 요청

### iOS 서명 설정이 함께 바뀌었다

`ios/Runner.xcodeproj/project.pbxproj` 에 **이번 작업과 무관한 변경**이 섞여 있다.
Xcode 로 빌드하면서 자동으로 바뀐 것으로 보인다.

```
- CODE_SIGN_STYLE = Manual
- PROVISIONING_PROFILE_SPECIFIER = "toIT Runner Dev Profile Sangwoo"
- PROVISIONING_PROFILE_SPECIFIER = "toIT ShareExtension Dev Profile Sangwoo"
- DEVELOPMENT_TEAM = ""
+ CODE_SIGN_STYLE = Automatic
+ DEVELOPMENT_TEAM = 86MPU972PJ
```

수동 프로파일 지정이 사라지고 자동 서명으로 바뀐다. **기존에 수동 프로파일로
빌드하던 환경은 영향을 받는다.** 머지 전에 되돌릴지 정해야 한다.

---

## 확인한 것

`flutter analyze` 오류·경고 0 (남은 124건은 기존 `info` 등급).

실기기에서 설정부터 수신까지 확인했다.

```
[ALARM] 생성요청 usersId=32 scheduleId=92909 alarmState=true offset=5 timeSetting=true
[ALARM] 예약생성 alarmId=4 예정=2026-08-24T02:55 offset=5분
[ALARM] 조회 window=2026-08-24T02:55~02:56 count=1
[ALARM] 발송시도 alarmId=4
[FCM]   전송성공 usersId=32
[ALARM] 발송성공 alarmId=4
[ALARM] 완료표시 alarmId=4 isSent=true
```

**앱이 포그라운드면 OS 가 배너를 자동으로 띄우지 않는다.** 확인할 때는 앱을
백그라운드로 내려야 한다.

---

## 알려진 이슈 (이번 범위 밖)

**앱 전체 알림 설정 화면이 서버 값을 안 읽어온다.**

```dart
// notification_settings_screen.dart
bool isAppNotificationEnabled = true;   // 들어올 때마다 무조건 켜짐으로 시작
```

껐다가 앱을 다시 켜면 서버에는 꺼져 있는데 화면에는 켜짐으로 보인다.

**토큰 등록이 간헐적으로 500 을 낸다.** 재설치 직후처럼 로그인과 토큰 갱신이 거의
동시에 일어나면 서버에서 같은 토큰을 두 번 INSERT 하려다 유니크 제약에 걸린다.
서버 쪽 문제라 백엔드에서 따로 고친다. 앱 동작에는 지장이 없다.
